### PR TITLE
Notebook detección de outliers

### DIFF
--- a/Fifa_outliers.ipynb
+++ b/Fifa_outliers.ipynb
@@ -1,0 +1,2034 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "9084a0fe",
+   "metadata": {},
+   "source": [
+    "## Importación librerias y dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "d3a4b68e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "\n",
+    "import matplotlib as plt\n",
+    "import seaborn as sns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "d81946ca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df=pd.read_csv('data\\players_total2.csv')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bdbaed62",
+   "metadata": {},
+   "source": [
+    "## Visualización de las variables numéricas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "31880824",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['Unnamed: 0', 'Unnamed: 0.1', 'sofifa_id', 'overall', 'potential', 'value_eur', 'wage_eur', 'age', 'height_cm', 'weight_kg', 'club_team_id', 'league_level', 'club_jersey_number', 'club_contract_valid_until', 'nationality_id', 'nation_team_id', 'nation_jersey_number', 'weak_foot', 'skill_moves', 'international_reputation', 'release_clause_eur', 'pace', 'shooting', 'passing', 'dribbling', 'defending', 'physic', 'attacking_crossing', 'attacking_finishing', 'attacking_heading_accuracy', 'attacking_short_passing', 'attacking_volleys', 'skill_dribbling', 'skill_curve', 'skill_fk_accuracy', 'skill_long_passing', 'skill_ball_control', 'movement_acceleration', 'movement_sprint_speed', 'movement_agility', 'movement_reactions', 'movement_balance', 'power_shot_power', 'power_jumping', 'power_stamina', 'power_strength', 'power_long_shots', 'mentality_aggression', 'mentality_interceptions', 'mentality_positioning', 'mentality_vision', 'mentality_penalties', 'mentality_composure', 'defending_marking_awareness', 'defending_standing_tackle', 'defending_sliding_tackle', 'goalkeeping_diving', 'goalkeeping_handling', 'goalkeeping_kicking', 'goalkeeping_positioning', 'goalkeeping_reflexes', 'goalkeeping_speed', 'año_version', 'progresion_anual']\n"
+     ]
+    }
+   ],
+   "source": [
+    "#ver las variables numéricas\n",
+    "pd.set_option('display.max_columns', None)\n",
+    "print(df.select_dtypes(include=np.number).columns.tolist())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "15277571",
+   "metadata": {},
+   "source": [
+    "## Funciones"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "e2edb194",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def outlier_treatment(datacolumn):\n",
+    "    sorted(datacolumn)\n",
+    "    Q1,Q3 = np.percentile(datacolumn , [25,75])\n",
+    "    IQR = Q3 - Q1\n",
+    "    lower_range = Q1 - (1.5 * IQR)\n",
+    "    upper_range = Q3 + (1.5 * IQR)\n",
+    "    return lower_range,upper_range"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "e9a061ad",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def outliers(column):\n",
+    "    lower_range,upper_range = outlier_treatment(column)\n",
+    "    out_inf=df[column<lower_range].count()[0]\n",
+    "    out_sup=df[column>upper_range].count()[0]\n",
+    "    return f'Hay {out_inf} outliers por debajo de {lower_range} y {out_sup} outliers por encima de {upper_range}.' "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "f3a546bc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def outlier_detector(col,n_outliers):\n",
+    "    '''Detecta los outliers en funcion del percentil. \n",
+    "    Si está por encima del percil 99% o per debajo del 1%\n",
+    "    \n",
+    "    Sample input: ('edad',5)\n",
+    "    Sample output: fila con 5 outliers por edad\n",
+    "    '''\n",
+    "    \n",
+    "    \n",
+    "    q_low = df[col].quantile(0.01)\n",
+    "    q_hi  = df[col].quantile(0.99)\n",
+    "    \n",
+    "    while True:\n",
+    "        try:\n",
+    "            p=input('¿Qué quieres obtener el outiler inferior (I) o el superior (S)?')\n",
+    "            if p ==\"I\":\n",
+    "                return df[df[col] < q_low].sort_values(by=[col],ascending=True).head(n_outliers)\n",
+    "            elif p==\"S\":\n",
+    "                return df[df[col] > q_hi].sort_values(by=[col],ascending=False).head(n_outliers)\n",
+    "        except:\n",
+    "            pass\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d82c867a",
+   "metadata": {},
+   "source": [
+    "## Analisis variables numéricas"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "68a1158b",
+   "metadata": {},
+   "source": [
+    "### Variable Age"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "8b60df5a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<AxesSubplot:>"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYQAAAD4CAYAAADsKpHdAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAAAT3ElEQVR4nO3dfYyd5Znf8e9vcUotvBCyJCOEUY0atFrAKl2PCBJKNS7R4gZUSAUrIxqMlsoRIlKitbQx+SdUK0vOqoQKpaA6dYQh2ThWXgQKYXcRMEKReIlJac3LongXizVYtigswVGC1uTqH+eezcGcMzOeOfZ5Br4f6eg853qe+5nr3DPMb54XH1JVSJL0O+NuQJLUDQaCJAkwECRJjYEgSQIMBElSs2zcDSzUGWecUatWrRq47pe//CWnnHLKiW3oGNnjaCyFHmFp9GmPo9H1Hp9++unXquqjA1dW1ZJ8rFmzpoZ59NFHh67rCnscjaXQY9XS6NMeR6PrPQK7a8jvVU8ZSZIAryFIkhoDQZIEGAiSpMZAkCQBBoIkqTEQJEmAgSBJagwESRKwhD+6Qsdm1eYHjnnMptVHuGEB4462b+vli96HpOPPIwRJEuARwgk385f6qP76lqRR8QhBkgQYCJKkxkCQJAEGgiSpMRAkSYCBIElqDARJEjCPQEhydpJHk7yQ5LkkX2j1W5O8kuSZ9vh035hbkuxN8mKSy/rqa5LsaevuSJJWPznJd1v9ySSrjsN7lSTNYj5HCEeATVX1B8DFwM1Jzmvrbq+qC9vjxwBt3XrgfGAdcGeSk9r2dwEbgXPbY12r3wi8UVUfB24Hvrr4tyZJOhZzBkJVHaiqn7Xlt4AXgLNmGXIlsLOq3q6ql4C9wEVJzgROrarHq6qAe4Cr+sbsaMvfAy6dOXqQJJ0Y6f1unufGvVM5jwEXAH8K3AD8AthN7yjijSRfB56oqm+1MduBB4F9wNaq+lSrfxL4UlVdkeRZYF1V7W/r/g74RFW9dtTX30jvCIOJiYk1O3fuHNjn4cOHWbFixbzf14m055U3AZhYDgd/NeZm5jCqHlefddridzJEl7/X/ZZCn/Y4Gl3vce3atU9X1eSgdfP+LKMkK4DvA1+sql8kuQv4c6Da823AnwCD/rKvWerMse63haptwDaAycnJmpqaGtjr9PQ0w9aN2w19n2V0255uf5TUqHrcd93U4psZosvf635LoU97HI2l0OMw87rLKMmH6IXBt6vqBwBVdbCq3qmq3wDfAC5qm+8Hzu4bvhJ4tdVXDqi/a0ySZcBpwOsLeUOSpIWZz11GAbYDL1TV1/rqZ/Zt9hng2bZ8P7C+3Tl0Dr2Lx09V1QHgrSQXt31eD9zXN2ZDW74aeKSO5VyWJGnR5nM+4BLgs8CeJM+02peBa5NcSO/Uzj7gcwBV9VySXcDz9O5Qurmq3mnjbgLuBpbTu67wYKtvB+5NspfekcH6xbwpSdKxmzMQquonDD7H/+NZxmwBtgyo76Z3Qfro+q+Ba+bqRZJ0/PgvlSVJgIEgSWoMBEkSYCBIkhoDQZIEGAiSpMZAkCQBBoIkqTEQJEmAgSBJagwESRJgIEiSGgNBkgQYCJKkxkCQJAEGgiSpMRAkSYCBIElqDARJEmAgSJIaA0GSBBgIkqTGQJAkAQaCJKkxECRJgIEgSWoMBEkSYCBIkhoDQZIEGAiSpGbOQEhydpJHk7yQ5LkkX2j1jyR5KMnP2/PpfWNuSbI3yYtJLuurr0myp627I0la/eQk3231J5OsOg7vVZI0i/kcIRwBNlXVHwAXAzcnOQ/YDDxcVecCD7fXtHXrgfOBdcCdSU5q+7oL2Aic2x7rWv1G4I2q+jhwO/DVEbw3SdIxmDMQqupAVf2sLb8FvACcBVwJ7Gib7QCuastXAjur6u2qegnYC1yU5Ezg1Kp6vKoKuOeoMTP7+h5w6czRgyTpxEjvd/M8N+6dynkMuAB4uao+3Lfujao6PcnXgSeq6lutvh14ENgHbK2qT7X6J4EvVdUVSZ4F1lXV/rbu74BPVNVrR339jfSOMJiYmFizc+fOgX0ePnyYFStWzPt9nUh7XnkTgInlcPBXY25mDqPqcfVZpy1+J0N0+Xvdbyn0aY+j0fUe165d+3RVTQ5at2y+O0myAvg+8MWq+sUsf8APWlGz1Gcb8+5C1TZgG8Dk5GRNTU0NbGB6epph68bths0PALBp9RFu2zPv6R+LUfW477qpxTczRJe/1/2WQp/2OBpLocdh5nWXUZIP0QuDb1fVD1r5YDsNRHs+1Or7gbP7hq8EXm31lQPq7xqTZBlwGvD6sb4ZSdLCzecuowDbgReq6mt9q+4HNrTlDcB9ffX17c6hc+hdPH6qqg4AbyW5uO3z+qPGzOzrauCROpZzWZKkRZvP+YBLgM8Ce5I802pfBrYCu5LcCLwMXANQVc8l2QU8T+8OpZur6p027ibgbmA5vesKD7b6duDeJHvpHRmsX9zbkiQdqzkDoap+wuBz/ACXDhmzBdgyoL6b3gXpo+u/pgWKJGk8/JfKkiTAQJAkNQaCJAkwECRJjYEgSQIMBElSYyBIkgADQZLUGAiSJMBAkCQ1BoIkCTAQJEmNgSBJAgwESVJjIEiSAANBktQYCJIkwECQJDUGgiQJMBAkSY2BIEkCDARJUmMgSJIAA0GS1BgIkiTAQJAkNQaCJAkwECRJjYEgSQLmEQhJvpnkUJJn+2q3JnklyTPt8em+dbck2ZvkxSSX9dXXJNnT1t2RJK1+cpLvtvqTSVaN+D1KkuZhPkcIdwPrBtRvr6oL2+PHAEnOA9YD57cxdyY5qW1/F7AROLc9ZvZ5I/BGVX0cuB346gLfiyRpEeYMhKp6DHh9nvu7EthZVW9X1UvAXuCiJGcCp1bV41VVwD3AVX1jdrTl7wGXzhw9SJJOnGWLGPv5JNcDu4FNVfUGcBbwRN82+1vtn9ry0XXa8z8AVNWRJG8Cvwe8dvQXTLKR3lEGExMTTE9PD2zs8OHDQ9eN26bVRwCYWP7b5a4aVY/H83vR5e91v6XQpz2OxlLocZiFBsJdwJ8D1Z5vA/4EGPSXfc1SZ4517y5WbQO2AUxOTtbU1NTA5qanpxm2btxu2PwA0PtFe9uexeTx8TeqHvddN7X4Zobo8ve631Lo0x5HYyn0OMyC/muvqoMzy0m+AfyovdwPnN236Urg1VZfOaDeP2Z/kmXAacz/FJWWgFUtBI+HTauP/HPIHm3f1suP29eV3o8WdNtpuyYw4zPAzB1I9wPr251D59C7ePxUVR0A3kpycbs+cD1wX9+YDW35auCRdp1BknQCzXmEkOQ7wBRwRpL9wFeAqSQX0ju1sw/4HEBVPZdkF/A8cAS4uareabu6id4dS8uBB9sDYDtwb5K99I4M1o/gfUmSjtGcgVBV1w4ob59l+y3AlgH13cAFA+q/Bq6Zqw9J0vHlv1SWJAEGgiSpMRAkSYCBIElqDARJEmAgSJIaA0GSBBgIkqTGQJAkAQaCJKkxECRJgIEgSWoMBEkSYCBIkhoDQZIEGAiSpMZAkCQBBoIkqTEQJEmAgSBJagwESRJgIEiSGgNBkgQYCJKkxkCQJAEGgiSpMRAkSYCBIElqDARJEmAgSJKaOQMhyTeTHErybF/tI0keSvLz9nx637pbkuxN8mKSy/rqa5LsaevuSJJWPznJd1v9ySSrRvweJUnzMJ8jhLuBdUfVNgMPV9W5wMPtNUnOA9YD57cxdyY5qY25C9gInNseM/u8EXijqj4O3A58daFvRpK0cHMGQlU9Brx+VPlKYEdb3gFc1VffWVVvV9VLwF7goiRnAqdW1eNVVcA9R42Z2df3gEtnjh4kSSfOsgWOm6iqAwBVdSDJx1r9LOCJvu32t9o/teWj6zNj/qHt60iSN4HfA147+osm2UjvKIOJiQmmp6cHNnf48OGh68Zt0+ojAEws/+1yVy31Hrv0M9Dln8kZ9jgaS6HHYRYaCMMM+su+ZqnPNua9xaptwDaAycnJmpqaGtjE9PQ0w9aN2w2bHwB6v8Ru2zPq6R+tpd7jvuumTmwzs+jyz+QMexyNpdDjMAu9y+hgOw1Eez7U6vuBs/u2Wwm82uorB9TfNSbJMuA03nuKSpJ0nC00EO4HNrTlDcB9ffX17c6hc+hdPH6qnV56K8nF7frA9UeNmdnX1cAj7TqDJOkEmvN8QJLvAFPAGUn2A18BtgK7ktwIvAxcA1BVzyXZBTwPHAFurqp32q5uonfH0nLgwfYA2A7cm2QvvSOD9SN5Z5KkYzJnIFTVtUNWXTpk+y3AlgH13cAFA+q/pgWKJGl8/JfKkiRg9HcZSZ2xqt3RdaLt23r5WL6utFgfyEAY1y8KSeoyTxlJkgADQZLUGAiSJMBAkCQ1BoIkCTAQJEmNgSBJAgwESVJjIEiSAANBktQYCJIkwECQJDUGgiQJMBAkSY2BIEkCDARJUmMgSJIAA0GS1BgIkiTAQJAkNQaCJAkwECRJjYEgSQIMBElSYyBIkgADQZLUGAiSJGCRgZBkX5I9SZ5JsrvVPpLkoSQ/b8+n921/S5K9SV5McllffU3bz94kdyTJYvqSJB27URwhrK2qC6tqsr3eDDxcVecCD7fXJDkPWA+cD6wD7kxyUhtzF7AROLc91o2gL0nSMTgep4yuBHa05R3AVX31nVX1dlW9BOwFLkpyJnBqVT1eVQXc0zdGknSCpPc7eIGDk5eAN4AC/mdVbUvyj1X14b5t3qiq05N8HXiiqr7V6tuBB4F9wNaq+lSrfxL4UlVdMeDrbaR3JMHExMSanTt3Duzr8OHDrFixYmjfe155cwHvdrQmlsPBX427i9nZ48KsPuu099Tm+pnsAnscja73uHbt2qf7zui8y7JF7vuSqno1yceAh5L87SzbDrouULPU31us2gZsA5icnKypqamBX2h6epph6wBu2PzALG2eGJtWH+G2PYud/uPLHhdm33VT76nN9TPZBfY4Gkuhx2EWdcqoql5tz4eAHwIXAQfbaSDa86G2+X7g7L7hK4FXW33lgLok6QRacCAkOSXJ784sA38EPAvcD2xom20A7mvL9wPrk5yc5Bx6F4+fqqoDwFtJLm53F13fN0aSdIIs5lh7Avhhu0N0GfCXVfVXSX4K7EpyI/AycA1AVT2XZBfwPHAEuLmq3mn7ugm4G1hO77rCg4voS5K0AAsOhKr6e+DfDKj/P+DSIWO2AFsG1HcDFyy0F0nS4vkvlSVJgIEgSWoMBEkSYCBIkhoDQZIEGAiSpMZAkCQBBoIkqTEQJEmAgSBJagwESRJgIEiSGgNBkgQYCJKkxkCQJAEGgiSpMRAkSYCBIElqDARJEmAgSJKaZeNuQHq/WbX5gffUNq0+wg0D6qO2b+vlx/1r6P3LIwRJEmAgSJIaA0GSBBgIkqTGQJAkAQaCJKkxECRJgIEgSWoMBEkS0KFASLIuyYtJ9ibZPO5+JOmDphOBkOQk4H8A/wE4D7g2yXnj7UqSPli68llGFwF7q+rvAZLsBK4Enh9rV9ISM+hzlOZrMZ+35GcovT+kqsbdA0muBtZV1X9prz8LfKKqPn/UdhuBje3l7wMvDtnlGcBrx6ndUbHH0VgKPcLS6NMeR6PrPf6rqvrooBVdOULIgNp7kqqqtgHb5txZsruqJkfR2PFij6OxFHqEpdGnPY7GUuhxmE5cQwD2A2f3vV4JvDqmXiTpA6krgfBT4Nwk5yT5F8B64P4x9yRJHyidOGVUVUeSfB74a+Ak4JtV9dwidjnnaaUOsMfRWAo9wtLo0x5HYyn0OFAnLipLksavK6eMJEljZiBIkoD3QSAk+WaSQ0me7avdmuSVJM+0x6fH3OPZSR5N8kKS55J8odU/kuShJD9vz6d3sMfOzGWSf5nkqST/p/X4X1u9S/M4rMfOzGNfrycl+d9JftRed2YeZ+mxU/OYZF+SPa2X3a3WuXmcryV/DSHJvwMOA/dU1QWtditwuKr+2zh7m5HkTODMqvpZkt8FngauAm4AXq+qre3zm06vqi91rMc/piNzmSTAKVV1OMmHgJ8AXwD+E92Zx2E9rqMj8zgjyZ8Ck8CpVXVFkr+gI/M4S4+30qF5TLIPmKyq1/pqnZvH+VryRwhV9Rjw+rj7mE1VHaiqn7Xlt4AXgLPofTzHjrbZDnq/gMdilh47o3oOt5cfao+iW/M4rMdOSbISuBz4X33lzswjDO1xKejUPB6LJR8Is/h8kv/bTil15pAtySrg3wJPAhNVdQB6v5CBj42xtX92VI/QoblspxCeAQ4BD1VV5+ZxSI/QoXkE/jvwZ8Bv+mqdmkcG9wjdmscC/ibJ0+l9tA50bx7n7f0aCHcB/xq4EDgA3DbWbpokK4DvA1+sql+Mu59BBvTYqbmsqneq6kJ6/5r9oiQXjLOfQYb02Jl5THIFcKiqnh5XD3OZpcfOzGNzSVX9Ib1Par65ncJest6XgVBVB9t/lL8BvkHv01THqp1P/j7w7ar6QSsfbOfuZ87hHxpXf62H9/TYxbkEqKp/BKbpnZvv1DzO6O+xY/N4CfAf2/nvncC/T/ItujWPA3vs2DxSVa+250PAD1s/XZrHY/K+DISZb0bzGeDZYdueCO1C43bghar6Wt+q+4ENbXkDcN+J7m3GsB67NJdJPprkw215OfAp4G/p1jwO7LFL81hVt1TVyqpaRe9jYh6pqv9Mh+ZxWI9dmsckp7QbMEhyCvBHrZ/OzOOx6sRHVyxGku8AU8AZSfYDXwGmklxI7/zePuBz4+qvuQT4LLCnnVsG+DKwFdiV5EbgZeCa8bQHDO/x2g7N5ZnAjvT+h0q/A+yqqh8leZzuzOOwHu/t0DwO06Wfx2H+okPzOAH8sPe3FMuAv6yqv0ryU7o/jwMt+dtOJUmj8b48ZSRJOnYGgiQJMBAkSY2BIEkCDARJUmMgSJIAA0GS1Px/PXEBlrb6D6cAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "df['age'].hist()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "3e4bab41",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<AxesSubplot:xlabel='age'>"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWAAAAEGCAYAAABbzE8LAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAAANCUlEQVR4nO3dcWxd51mA8ed1PClpvUIbj6hyhyKwUEGrVFZrAlUCq0rBLSuwoiKQoJk0aSC1TiiVKPBPXCGhZaKIxhSkDiY5wECL2g4Spc5SjWwaYlBndEu3FrCgIExpWge2WnVBjj/+8LmR7djxvc699z23fX6SFZ97Tu557xfnycmxbEcpBUlS9/VlDyBJ71YGWJKSGGBJSmKAJSmJAZakJP2tHDw4OFj27t3boVEk6Z1ncHCQU6dOnSqljK3f11KA9+7dy8zMTPsmk6R3gYgY3Ohxb0FIUhIDLElJDLAkJTHAkpTEAEtSEgMsSUkMsCQlMcCSlMQAS1ISAyxJSQywJCUxwJKUxABLUhIDLElJDLAkJTHAkpTEAEtSEgMsSUkMsCQlaelnwr2bTU5OMjs729FzzM3NATA0NNTR8wwPDzM+Pt7Rc0jamgFu0uzsLC+8+BIXr7mhY+fY8da3APiv/+3cH8uOty507LkltcYAt+DiNTewePPdHXv+XS+fBOjKOSTl8x6wJCUxwJKUxABLUhIDLElJDLAkJTHAkpTEAEtSEgMsSUkMsCQlMcCSlMQAS1ISAyxJSQywJCUxwJKUxABLUhIDLElJDLAkJTHAkpTEAEtSEgMsSUkMsCQlMcCSlMQAS1ISAyxJSQywJCUxwJKUxABLUhIDLElJDLAkJTHAkpTEAEtSEgMsSUkMsCQlMcCSlMQAS1ISAyxJSQywJCUxwJKUxABLUhIDLElJDLAkJelKgCcnJ5mcnOzGqaS28GNW3dDfjZPMzs524zRS2/gxq27wFoQkJTHAkpTEAEtSEgMsSUkMsCQlMcCSlMQAS1ISAyxJSQywJCUxwJKUxABLUhIDLElJDLAkJTHAkpTEAEtSEgMsSUkMsCQlMcCSlMQAS1ISAyxJSQywJCUxwJKUxABLUhIDLElJDLAkJTHAkpTEAEtSEgMsSUkMsCQlMcCSlMQAS1ISAyxJSQywJCUxwJKUxABLUhIDLElJDLAkJTHAkpTEAEvbMDo6eultO/vHxsYYHR3lrrvu2vQchw8fZnR0lMcee2zD/UeOHGF0dJQnnnhiw/0zMzPccccdnD17dlv75+fnOXDgAPPz85vO2Mwxva6Tr9EASwnefvttABYXFzc95tlnnwXg+PHjG+5/+umnATh27NiG+ycmJlheXubQoUPb2j81NcW5c+c4evTopjM2c0yv6+RrNMBSi9Zf1ba6PTY2tmZ7o6vgw4cPr9lefxV85MiRNdvrr4JnZmZYWFgAYGFh4bKr3K32z8/PMz09TSmF6enpDa/+mjmm13X6Nfa39dk2MTc3x+LiIgcPHuzG6TpidnaWvv8r2WNctb63v83s7Js9/WfRDbOzs+zatasjz924+m3Y6Cq4cfXbcPz4cR5++OFL242r34Zjx47xwAMPXNqemJhYs//QoUOcOHGi6f1TU1MsLy8DcPHiRY4ePcpDDz205vc0c0yv6/Rr3PIKOCI+HhEzETHz+uuvt+3EkjqncXW73e3nnnuOpaUlAJaWljh9+vRl52jmmF7X6de45RVwKeVJ4EmAkZGRbV0CDg0NAfD4449v57fXwsGDBzn7L69lj3HVlndex/D37OnpP4tu6PX/IQwMDKyJ6sDAQEv79+3bx8mTJ1laWqK/v58777zzsnM0c0yv6/Rr9B6w1GU7d+5cs73RrY7194XvueeeNdv33nvvmu377rtvzfb6WwyPPvpoS/v3799PX99KHnbs2MH9999/2YzNHNPrOv0aDbDUojNnzlzV9vT09Jrt9fd7AR555JE126vv/wIcOHBgzfbq+78AIyMjl65qBwYGuO2221rav3v3bsbGxogIxsbG2L1792UzNnNMr+v0azTAUoLGVfCVPtHXuApef/Xb0LgKXn/12zAxMUFfX99lV7fN7t+/fz+33HLLFa/6mjmm13XyNUYpzd/WHRkZKTMzMy2fpHE/rZfvOzbuAS/efHfHzrHr5ZMAHT/Hbd4D3tI74WNW9RERZ0spI+sf9wpYkpIYYElKYoAlKYkBlqQkBliSkhhgSUpigCUpiQGWpCQGWJKSGGBJSmKAJSmJAZakJAZYkpIYYElKYoAlKYkBlqQkBliSkhhgSUpigCUpiQGWpCQGWJKSGGBJSmKAJSmJAZakJAZYkpIYYElKYoAlKYkBlqQkBliSkhhgSUpigCUpiQGWpCQGWJKSGGBJSmKAJSmJAZakJAZYkpIYYElK0t+NkwwPD3fjNFLb+DGrbuhKgMfHx7txGqlt/JhVN3gLQpKSGGBJSmKAJSmJAZakJAZYkpIYYElKYoAlKYkBlqQkBliSkhhgSUpigCUpiQGWpCQGWJKSGGBJSmKAJSmJAZakJAZYkpIYYElKYoAlKYkBlqQkBliSkhhgSUpigCUpiQGWpCQGWJKSGGBJSmKAJSmJAZakJAZYkpIYYElKYoAlKYkBlqQkBliSkhhgSUpigCUpiQGWpCQGWJKSGGBJSmKAJSmJAZakJP3ZA/SSHW9dYNfLJzv4/PMAHT7HBWBPx55fUvMMcJOGh4c7fo65uSUAhoY6Gcg9XXktkrZmgJs0Pj6ePYKkdxjvAUtSEgMsSUkMsCQlMcCSlMQAS1ISAyxJSQywJCUxwJKUxABLUhIDLElJDLAkJTHAkpTEAEtSEgMsSUkMsCQlMcCSlMQAS1ISAyxJSQywJCUxwJKUJEopzR8c8Trwb5vsHgTeaMdQHeSM7eGM7eGM7VPnOd8AKKWMrd/RUoCvJCJmSikjbXmyDnHG9nDG9nDG9umVOdfzFoQkJTHAkpSknQF+so3P1SnO2B7O2B7O2D69MucabbsHLElqjbcgJCmJAZakJC0HOCI+HRHnI+LFVY9NRMRcRLxQvd3d3jFbnvH9EfHXEfFSRHwjIg5Wj98QEacj4p+rX6+v4Yy1WcuI2BkRfx8RX6tmfLR6vDbruMWctVnLap4dEfEPEXGi2q7VOjZsMGfd1vGViDhXzTJTPVbLtdxKy/eAI+JHgAXgaCnlA9VjE8BCKeV32j7hNkTEjcCNpZSvRsR7gbPATwMfBS6UUj4REb8OXF9KeaRmM/4sNVnLiAjg2lLKQkS8B/gycBC4l5qs4xZzjlGTtQSIiF8FRoDrSikfjohPUqN1bNhgzgnqtY6vACOllDdWPVbLtdxKy1fApZQvARc6MEvblFJeLaV8tXr/TeAlYAj4KWCqOmyKleCluMKMtVFWLFSb76neCjVaR7jinLURETcBPwH80aqHa7WOsOmcvaB2a9mMdt4DfjAivl7doqjN5X9E7AV+EPg7YE8p5VVYCSDwXYmjXbJuRqjRWlb/HX0BOA+cLqXUch03mRPqs5a/B/wasLzqsdqtIxvPCfVZR1j5x/XzEXE2Ij5ePVbHtdxSuwL8h8D3ArcCrwKPtel5r0pEDABPAb9SSvl29jwb2WDGWq1lKeViKeVW4CbgQxHxgcx5NrPJnLVYy4j4MHC+lHI24/zNusKctVjHVW4vpXwQuAt4oLot2pPaEuBSymvVX4Bl4FPAh9rxvFejuhf4FPBnpZSnq4dfq+69Nu7Bns+ar5rhshnruJYApZT/Ac6wcl+1Vuu42uo5a7SWtwM/Wd27/Avgjoj4U+q3jhvOWaN1BKCU8p/Vr+eBZ6p56raWTWlLgBsvvPIR4MXNju2G6pMyfwy8VEr53VW7/grYX72/H/jLbs/WsNmMdVrLiHhfRHxn9f4uYB/wMjVaR9h8zrqsZSnlN0opN5VS9gI/B3yhlPIL1GwdN5uzLusIEBHXVp+0JiKuBX6smqdWa9ms/lZ/Q0T8OTAKDEbEfwCHgNGIuJWVezOvAL/UvhG35XbgF4Fz1X1BgN8EPgF8NiI+Bvw7cF/OeMDmM/58jdbyRmAqInaw8o/1Z0spJyLib6nPOsLmc/5JjdZyI3X6eLyST9ZoHfcAz6xcv9APfKaUMh0Rz9Mba7mGX4osSUn8SjhJSmKAJSmJAZakJAZYkpIYYElKYoAlKYkBlqQkBlg9ISI+V33zlW80vgFLRHwsIv4pIs5ExKci4verx98XEU9FxPPV2+2500sb8wsx1BMi4oZSyoXqS42fB34c+Bvgg8CbwBeAr5VSHoyIzwB/UEr5ckR8N3CqlPL9acNLm2j5S5GlJAci4iPV++9n5cu4v1hKuQAQEceA76v27wN+oPpyVYDrIuK91fddlmrDAKv2ImKUlaj+cCnlrYg4A/wjsNlVbV917GJXBpS2yXvA6gXfAfx3Fd+bgR8CrgF+NCKuj4h+4GdWHf954MHGRvWNZKTaMcDqBdNAf0R8Hfgt4CvAHPDbrPwUkeeAbwLfqo4/AIxUP8Hhm8Avd39kaWt+Ek49KyIGqh/E2c/KN+b+dCnlmey5pGZ5BaxeNlF9L+UXgX8FPpc6jdQir4AlKYlXwJKUxABLUhIDLElJDLAkJTHAkpTk/wHqpYVF+AP1KgAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "sns.boxplot(x=df['age'],whis=1.5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "d129dab3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Hay 0 outliers por debajo de 13.0 y 257 outliers por encima de 37.0.'"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "outliers(df['age'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "15d741b9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "52"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df[df['age']>=40].count()[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "bd04ce7d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Podemos considerar que a partir de los 40 años de edad tenemos 52 outliers. \\nSi la edad es una variable relevante podemos decidir eliminar estos outliers para que no distorsionen la prevision'"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "'''Podemos considerar que a partir de los 40 años de edad tenemos 52 outliers. \n",
+    "Si la edad es una variable relevante podemos decidir eliminar estos outliers para que no distorsionen la prevision'''"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c79fa362",
+   "metadata": {},
+   "source": [
+    "### Variable Height_cm"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "c81939d0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<AxesSubplot:xlabel='height_cm'>"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWYAAAEHCAYAAACdjuzpAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAAAQQUlEQVR4nO3df2zU933H8dcb3wYU0y2QgjIn6nVz23QRCituxaZ2OZxkePGyXyiUCgSoUSaqyaFITCJxNIwGEWuzTRFbh4jaAgtrmi7VVhLklPCjnbQmnV2RkAzSXBtHhWYhcdYECKE1/uyP7/fr3Pfw2T7s873v/HxIlr/f933ue5+3zb38ue/hry2EIACAH9OqPQEAQBrBDADOEMwA4AzBDADOEMwA4EymnMFXX311yGazFZoKANSn3t7eN0IIHxjr+LKCOZvNqqenp/xZAcAUZmavlDOeUxkA4AzBDADOEMwA4AzBDADOEMwA4AzBDADOEMwA4AzBDADOEMwA4AzBDADOEMwA4AzBDADOEMwA4AzBDADOEMwA4AzBDADOEMwA4AzBDADOEMwA4ExZf/MPKMeOHTuUz+crcuzTp09Lkpqamipy/FKam5vV0dExqY+JqYdgRsXk83kde/6ELr1vzoQfu+GdtyRJ/3tx8v4JN7zz5qQ9FqY2ghkVdel9c3Th+tsm/LgzTx6QpIoce7THBCqNc8wA4AzBDADOEMwA4AzBDADOEMwA4AzBDADOEMwA4AzBDADOEMwA4AzBDADOEMwA4AzBDADOEMwA4AzBDADOEMwA4AzBDADOEMwA4AzBDADOEMwA4AzBDADOEMwA4AzBDADOEMwA4AzBDADOEMwA4AzBDADOEMwA4AzBDADOEMwA4AzBDADOEMwA4AzBDADOEMwA4AzBDADOEMwA4AzBDADOEMwA4AzBDADOEMwA4AzBDADOEMwA4AzBfAV27NihHTt2VHsagFs8R8YnU+0J1KJ8Pl/tKQCu8RwZH1bMAOAMwQwAzhDMAOAMwQwAzhDMAOAMwQwAzhDMAOAMwQwAzhDMAOAMwQwAzhDMAOAMwQwAzhDMAOAMwQwAzhDMAOAMwQwAzhDMAOAMwQwAzhDMAOAMwQwAzhDMAOAMwQwAzhDMAOAMwQwAzhDMAOAMwQwAzhDMAOAMwQwAzhDMAOAMwQwAzhDMAOAMwQwAzhDMAOAMwQwAzhDMAOAMwQwAzhDMAOAMwQwAzkxKMO/bt0+5XE6PPPJIqn748GHlcjkdOXJk1LHLli1TLpfT8uXLU/UtW7Yol8tp27ZtqfrSpUuVy+XU1tY2VGtvb1cul9Ptt9+eGpvL5YY+xlIHUL7W1lblcjndfPPNqXqp59nGjRuVy+W0adOmVH3VqlXK5XJau3btUC2fz6u9vV35fD41tqenR62trert7U3V+/v7dffdd6u/v3/UeZczdqJMSjA/9NBDkqSdO3em6vfff78kpUK11Njki3LmzJlUPQn1gwcPpuoXL16UJL377rtDtfPnz0uSzp49ewVdABiPwcFBSdKlS5fGNL6np0eS9PTTT6fqp06dkiT19fUN1bZu3arz589r69atqbFdXV0aHBzU5s2bU/U9e/bo+PHj2rt376jzKGfsRKl4MO/bty+1n6yEDx8+rIGBAUnSwMCAjhw5UnLssmXLUvVk1bxly5ZUPQn4pUuXpuptbW1qb29P1ZJV83Cr5JHqAMrX2tqa2k9WzaWeZxs3bkzVk1XzqlWrUvW1a9cqn88PhXRfX9/Qqrmnp0fnzp2TJJ07d25o1dzf36/u7m6FENTd3T3iSricsRMpU+kHSFbAiZ07d2rFihVDq+XEtm3bhoK6eGzxFyNZNReeApGiVXNnZ+fQajlRuGpOjGfVfPr0aV24cEHr16+/4mNMBfl8XtN+Eao9jQkz7d23lc+f5fs+Bvl8XjNnzhzaT1bLidFWzclqOZGsmpPVcqKvr++yVfLWrVu1e/dudXV1peqbN2/W448/rj179qRW73v37tWGDRuGnUc5YyfSqCtmM/sLM+sxs57XX399wh64OISL9wFgLApPaRTuJ6vlRLL/1FNPpV6tF58GLVTO2Ik06oo5hLBL0i5JamlpmbDlTyaTSYVx8b5nTU1NkqQHH3ywyjPxbf369er9yWvVnsaEGZzxfjX/5ny+72Mwma8qstlsKpyz2awkqbGxMRXOjY2NkqRbbrlFBw4c0MDAgDKZjG699daSxy5n7ESq+Dnmu+66K7W/bt06SdK9996bqnd2dpYcO3fu3FR93rx5kqQlS5ak6skXbfr06an6jBkzNGvWrFRt9uzZY+4BwPhMm5aOmoaGhhHHt7S0pPYXL14sSbr22mtT9Ww2q/vuuy9VS/aLT2Uk70mtWbNmaD4NDQ1avXp1yXmUM3YiVTyYV65cmdpfsWKFpOjNgEwmWrBnMhktWbKk5NjHHnssVX/00Ucl6bJ3Wjs7OyVJTz75ZKre3d2tJ554IlXbv3+/JOno0aOperJfqg6gfIcPH07tHzp0SFLp59kDDzyQqm/fvl2S9PDDD6fqu3fvVnNz89AqOZvNqrm5WVIU7skqubGxUYsWLZIULfTa2tpkZmpra7ts4VeonLETaVL+u1yyEk5WwIlk1ZwE6khjky9IslpOJKvm4pcYyap5xowZQ7Vk1cxqGZh8hSvPsUhWzclqOZGsmpMwlqJV8qxZsy5bPXd1dWnatGmX/Q+uNWvWaMGCBWNaAZczdqJYCGM/bdzS0hKK3y2dipLzZ5xrHFlyjvnC9bdN+LFnnjwgSRU59kiPuYhzzGPCcyTNzHpDCC2jj4zwK9kA4AzBDADOEMwA4AzBDADOEMwA4AzBDADOEMwA4AzBDADOEMwA4AzBDADOEMwA4AzBDADOEMwA4AzBDADOEMwA4AzBDADOEMwA4AzBDADOEMwA4AzBDADOEMwA4AzBDADOEMwA4AzBDADOEMwA4AzBDADOEMwA4AzBDADOEMwA4AzBDADOEMwA4AzBDADOEMwA4AzBDADOEMwA4AzBDADOEMwA4AzBDADOZKo9gVrU3Nxc7SkArvEcGR+C+Qp0dHRUewqAazxHxodTGQDgDMEMAM4QzADgDMEMAM4QzADgDMEMAM4QzADgDMEMAM4QzADgDMEMAM4QzADgDMEMAM4QzADgDMEMAM4QzADgDMEMAM4QzADgDMEMAM4QzADgDMEMAM4QzADgDMEMAM4QzADgDMEMAM4QzADgDMEMAM4QzADgDMEMAM4QzADgDMEMAM4QzADgDMEMAM4QzADgDMEMAM4QzADgDMEMAM4QzADgDMEMAM4QzADgDMEMAM5kqj0B1LeGd97UzJMHKnDcfkmqyLFLP+abkuZP2uNh6iKYUTHNzc0VO/bp0wOSpKamyQzK+RXtCUgQzKiYjo6Oak8BqEmcYwYAZwhmAHCGYAYAZwhmAHCGYAYAZwhmAHCGYAYAZwhmAHCGYAYAZwhmAHCGYAYAZwhmAHCGYAYAZwhmAHCGYAYAZwhmAHCGYAYAZwhmAHCGYAYAZwhmAHDGQghjH2z2uqRXKjedCXe1pDeqPYkKo8f6MRX6nAo9Spf3+cEQwgfGeueygrnWmFlPCKGl2vOoJHqsH1Ohz6nQozT+PjmVAQDOEMwA4Ey9B/Ouak9gEtBj/ZgKfU6FHqVx9lnX55gBoBbV+4oZAGoOwQwAztRsMJvZV83sjJk9X1TvMLMXzewFM/tiQf0eM8vHty2d/BlfmeH6NLNvmNmx+KPPzI4V3FZzfZbocaGZPR332GNmnyy4rV56vNHMvm9mx81sv5m9v+C2mutRkszsOjM7YmYn4ufg+rg+x8wOmtlL8eerCu5TU72O0OMd8f6gmbUU3ae8HkMINfkh6fclfVzS8wW1JZKekjQ93p8Xf/5tSc9Kmi7pQ5J+LKmh2j1caZ9Ft/+dpL+u5T5LfC+/I+kP4+3bJB2twx7/W9JN8fbnJP1NLfcYz/0aSR+Pt2dL+lHczxclbYrrmyT9ba32OkKPH5P0UUlHJbUUjC+7x5pdMYcQvifpzaLy5yVtDyFcjMeciet/IumREMLFEMLLkvKSPqkaUKJPSZKZmaTlkr4el2qyzxI9BknJCvLXJP0s3q6nHj8q6Xvx9kFJy+LtmuxRkkIIr4YQfhhvn5V0QlKTop72xMP2SPrTeLvmei3VYwjhRAjhxWHuUnaPNRvMJXxE0qfN7Bkz+66ZfSKuN0n6acG4U3Gt1n1a0mshhJfi/Xrq8wuSvmRmP5X0gKR74no99fi8pD+Ot++QdF28XRc9mllW0u9IekbS/BDCq1IUbJLmxcNquteiHkspu8d6C+aMpKskLZb0V5IejVeVNszYevh/gp/Ve6tlqb76/LykDSGE6yRtkPSVuF5PPX5O0l+aWa+il8S/iOs136OZNUp6TNIXQghvjzR0mFpN9FrJHustmE9J+laI/EDSoKKLiZzSe6sRSbpW7700rklmlpH055K+UVCupz7XSPpWvP1NvffSr256DCGcDCH8QQhhkaIfsD+Ob6rpHs3sVxQF1r4QQvI9fM3Mrolvv0ZScpqxJnst0WMpZfdYb8H875JaJcnMPiLpVxVd4enbklaY2XQz+5CkD0v6QbUmOUFukXQyhHCqoFZPff5M0k3xdquk5HRN3fRoZvPiz9Mk3SdpZ3xTzfYYv0L9iqQTIYS/L7jp24p+2Cr+/B8F9ZrqdYQeSym/x2q/wzmOd0a/LulVSb9U9BPpTkVB/LCic3c/lNRaML5T0YrkRcXv9tfCx3B9xvXdktYNM77m+izxvfyUpF5F72Y/I2lRHfa4XtE7+j+StF3xb+LWao/xvD+l6GX6c5KOxR+3SZor6ZCiH7CHJM2p1V5H6PHP4u/tRUmvSXrySnvkV7IBwJl6O5UBADWPYAYAZwhmAHCGYAYAZwhmAHCGYAYAZwhmVJyZZYsvzzrK+HVmtnqUMWvN7B9L3HZvuXMEPCGY4U4IYWcIYe84DkEwo6YRzJgsDWb2UHwh8e+Y2Uwz+y0z6zazXjP7TzO7XpLMrMvMNsbbnzCz5+ILyn+paOX9G/H9X7L4jyKY2XZJM+ML7O8rNRkzWx0f91kz+5e4ttvM/jm+CPpPzOym+AL3J8xsd8W+MkARghmT5cOS/imEcIOknyu69vAuSR0huojPRklfHuZ+X1P0q+e/K+lS0W0LJX1G0gJJnzGz60IImyRdCCEsDCGsHG4iZnaDol+RbQ0h3KjoV6MTVym6NscGSfsl/YOkGyQtMLOF5TYNXIlMtSeAKePlEMKxeLtXUlbS70n6ZnRNGEnRX3gYYma/Lml2COG/4tK/SvqjgiGHQghvxWP/R9IHlb7ubSmtkv4thPCGJIUQCi9gvz+EEMzsuKJrXR+Pj/9CPOdjAiqMYMZkuViwfUnSfEk/DyEsHOE+w13HdqRjjvXfs6n09XCTYw4WHX+wjOMD48KpDFTL25JeNrM7pOhSimZ2Y+GAEML/STprZovj0ooxHvuX8fVySzkkabmZzY0fe055Uwcqi2BGNa2UdKeZPSvpBUV/G63YnZJ2mdn3Fa103xrDcXdJeq7Um38hhBckbZP03fixx3JNXWDScNlPuGZmjSGEc/H2JknXhBDWj3I3oKZxzgzetZvZPYr+rb4iaW11pwNUHitm1K34HPKhYW66OYTQP9nzAcaKYAYAZ3jzDwCcIZgBwBmCGQCcIZgBwJn/B630RVImti6bAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "sns.boxplot(x=df['height_cm'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "924bb12e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Hay 249 outliers por debajo de 163.5 y 126 outliers por encima de 199.5.'"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "outliers(df['height_cm'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "f4ba8644",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Mejor no eliminar estos outliers porque son características físicas que pueden ir bien para una determinada posición (GK)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "af407240",
+   "metadata": {},
+   "source": [
+    "### Variable weight_kg"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "76e83141",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<AxesSubplot:xlabel='weight_kg'>"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWAAAAEHCAYAAACQkJyuAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAAAQBElEQVR4nO3df5CcdX3A8ffHXNUQMZWgDIbWUw5l/DGlkjqxVLoIkUC0GSmZiYVJrhgcZpgk6jA2Sjo2HWDoDKODkdYxNI0USmZg0GgnEyVCKqOCJBYEBepWowYVYmgpQkqNfvvH7p63l83d3rG7n9vL+zWTudsvz7PP95vLve+5Z4/nopSCJKn3XpQ9AUk6WhlgSUpigCUpiQGWpCQGWJKSDExm4+OPP74MDg52aSqSNDPt2bPnF6WUV44dn1SABwcH2b17d+dmJUlHgYj4UatxL0FIUhIDLElJDLAkJTHAkpTEAEtSEgMsSUkMsCQlMcCSlMQAS1ISAyxJSQywJCUxwJKUxABLUhIDLElJDLAkJTHAkpTEAEtSEgMsSUkMsCQlmdTvhNPMtXHjRqrValeP8fjjjwMwf/78rh5naGiI1atXd/UYUicYYAFQrVZ54OFH+PUxx3XtGLOeexqAnz/fvX92s557qmvPLXWaAdaIXx9zHAdPPb9rzz/70e0APTmG1A+8BixJSQywJCUxwJKUxABLUhIDLElJDLAkJTHAkpTEAEtSEgMsSUkMsCQlMcCSlMQAS1ISAyxJSQywJCUxwJKUxABLUhIDLElJDLAkJTHAkpTEAEtSEgMsSUkMsCQlMcCSlMQAS1ISAyxJSQywJCUxwJKUxABLUhIDLElJDLAkJTHAkpTEAEtSEgMsSUkMsCQlMcCSlMQAS1ISAyxJSQywJCUxwJKUxABLUhIDLElJZnSAN27cyMaNG7OnIU07fm5MDwPZE+imarWaPQVpWvJzY3qY0WfAkjSdGWBJSmKAJSmJAZakJAZYkpIYYElKYoAlKYkBlqQkBliSkhhgSUpigCUpiQGWpCQGWJKSGGBJSmKAJSmJAZakJAZYkpIYYElKYoAlKYkBlqQkBliSkhhgSUpigCUpiQGWpCQGWJKSGGBJSmKAJSmJAZakJAZYkpIYYElKYoAlKYkBlqQkBliSkhhgSUpigCUpiQGWpCQGWJKSGGBJStKTAFerVZYsWUK1Wh0Z+9SnPkWlUuGGG24Yd7tbbrmFSqXC1q1bx913eHiYSqXCqlWrurwaaWaqVCojfyY7dvHFF1OpVBgeHh4Ze8973kOlUmHp0qUjY1dccQWVSoV169aNu++mTZuoVCps3rx5ZOyuu+6iUqlw9913j7uOAwcOsGbNGg4cODAy1qoj7dqwYQOVSoWrr7560vtOpCcBvuqqq3j22We56qqrRsbuuOMOAG677bZxt9u0aRMAn/nMZ8bdd+/evQBN8ZbUG/v27QN++3kI8MwzzwDw9NNPj4zt3r0bgHvvvXfcfW+55RYAbrrpppGxa665BmDCEH7uc5/joYceatq3VUfa1Qj+nXfeOel9JzLQ8Wcco1qtjvzF7t27l2q1yvbt25u2ueGGGzj33HMP2+6+++5r2m7r1q08+eSTh+17//33N42tWrWKG2+8sbMLkWaw0WezrR6PN3bSSSc1jQ0PDzedfQIsXbqUU045pWls3bp1I/Edve8ZZ5zRNLZ582YGBwc5dOgQAIcOHeLuu+/mrLPOOmw+Bw4cYMeOHZRS2LFjBytWrGDHjh1N22zdupXly5cftm8rGzZsaHp89dVXc+WVV7a1bzuilNL2xgsWLCiNr2DtGh4ebvrKNjg42PT4SONH2q5du3bt4sILL+TgwYMMDQ1N+XmOFtVqlWf+r/Dsae39w5yK2Y/WvvAePPX8rh1jzgNbOfbF4cd8AtVqldmzZ3P77bcDreM6nQwMDIwEuPF4586dh233iU98gu3bt3Po0CEGBgZYsmQJ27ZtO2y7Xbt2tXXcVn8v7e47WkTsKaUsGDs+4SWIiPhAROyOiN379++f9IHHRvRIUW13O0lHn9HxbfW4YefOnU1nyt24bNBJE16CKKV8Fvgs1M6AJ3uAds9sO30GDDB//nwArr/++hf0PEeDtWvXsucHT2RP4wX7zUtfztDrTvBjPoG1a9dmT2FSWp0Bt3LOOec0nQEvWrSo5RnwdNH1F+HWr19/2OMLLrigaWzZsmUtt7v00kubxi677LKW+w4ODjaN+e2n1DtjrwEPDg5y7LHHNo3NnTuXBQuavwNfuHBhy30vuuiiprEVK1bwsY99rGnsSNdhV65cyYteVMvarFmzWLFiRcuOtGvsdeZFixa1vW87uh7goaGhkUAODg4yNDTEmjVrmra5/PLLW2439gOxfPnylvtu2bKlacwX4KTJGXtdc9euXW2P3XzzzU1jW7Zs4Utf+lLT2LZt27juuuuaxq699tqW+44N5iWXXMI73/nOkbPegYGBli/AAcybN4/FixcTESxevJh58+a17Ei7Pv7xjzc97uQLcNCjH0Nbv349c+bMaTrLbZzJLlu2bNztGh+M0V+1Wu3biLdnv1LvNc5kR3832jgLnjt37shY4yx44cKF4+7biOaKFStGxhpnwRNFcOXKlbzlLW9p2rdVR9rViH2nz36hBz8FkalxncvrgRNrXAPu5k8o9OKnIGY/up3TvQY8IT83emvKPwUhSeoOAyxJSQywJCUxwJKUxABLUhIDLElJDLAkJTHAkpTEAEtSEgMsSUkMsCQlMcCSlMQAS1ISAyxJSQywJCUxwJKUxABLUhIDLElJDLAkJTHAkpTEAEtSEgMsSUkMsCQlMcCSlMQAS1ISAyxJSQywJCUxwJKUxABLUhIDLElJDLAkJTHAkpTEAEtSEgMsSUkMsCQlMcCSlMQAS1ISAyxJSQayJ9BNQ0ND2VOQpiU/N6aHGR3g1atXZ09Bmpb83JgevAQhSUkMsCQlMcCSlMQAS1ISAyxJSQywJCUxwJKUxABLUhIDLElJDLAkJTHAkpTEAEtSEgMsSUkMsCQlMcCSlMQAS1ISAyxJSQywJCUxwJKUxABLUhIDLElJDLAkJTHAkpTEAEtSEgMsSUkMsCQlMcCSlMQAS1ISAyxJSQywJCUxwJKUxABLUhIDLElJDLAkJTHAkpTEAEtSEgMsSUkMsCQlMcCSlMQAS1KSgewJaPqY9dxTzH50exef/wBAl4/xFHBC155f6iQDLACGhoa6fozHHz8EwPz53QzkCT1Zi9QJBlgArF69OnsK0lHHa8CSlMQAS1ISAyxJSQywJCUxwJKUxABLUhIDLElJDLAkJTHAkpTEAEtSEgMsSUkMsCQlMcCSlMQAS1ISAyxJSQywJCUxwJKUxABLUhIDLElJDLAkJYlSSvsbR+wHftTB4x8P/KKDz5fFdUwvM2EdM2EN4DoaXlNKeeXYwUkFuNMiYncpZUHaBDrEdUwvM2EdM2EN4Dom4iUISUpigCUpSXaAP5t8/E5xHdPLTFjHTFgDuI5xpV4DlqSjWfYZsCQdtQywJCXpWYAjYm9EPBQRD0TE7vrYcRFxZ0R8v/72Fb2az1RFxO9GxO0R8WhEPBIRb++3dUTEG+ofh8af/4mID/bbOgAi4kMR8d2IeDgibo2Il/bpOtbW1/DdiPhgfWzaryMiNkfEkxHx8KixI847Ij4aEdWIeCwizs2Z9eGOsI5l9Y/HbyJiwZjtO7KOXp8Bn1VKOW3Uz9OtA75aSjkF+Gr98XR3PbCjlHIq8AfAI/TZOkopj9U/DqcBpwPPAZ+nz9YREfOBNcCCUsqbgVnAcvpvHW8GLgXeRu3f1Lsj4hT6Yx1bgMVjxlrOOyLeSO3j86b6Pn8fEbN6N9VxbeHwdTwMXAB8bfRgR9dRSunJH2AvcPyYsceAE+vvnwg81qv5THENLwd+SP3Fy35dx5i5vwv4ej+uA5gP/AQ4DhgA/rW+nn5bxzLgxlGP/xr4SL+sAxgEHh71uOW8gY8CHx213ZeBt2fP/0jrGDW+i9oX+cbjjq2jl2fABfhKROyJiA/Ux04opfwMoP72VT2cz1S8DtgP/FNE/HtE3BgRc+i/dYy2HLi1/n5fraOU8jhwHfBj4GfA06WUr9Bn66B2pnVmRMyLiGOA84Hfo//W0XCkeTe+YDbsq4/1m46to5cBPqOU8lbgPODyiDizh8fulAHgrcA/lFL+EHiW6fltYVsi4sXAnwG3Zc9lKurXFpcCrwVeDcyJiItzZzV5pZRHgL8D7gR2AA8Ch1In1R3RYqwffw62Y+voWYBLKT+tv32S2vXGtwFPRMSJAPW3T/ZqPlO0D9hXSrmv/vh2akHut3U0nAd8u5TyRP1xv63jHOCHpZT9pZRfAXcAf0z/rYNSyj+WUt5aSjkTeAr4Pn24jrojzXsftTP7hpOAn/Z4bp3QsXX0JMARMScijm28T+063cPAF4GV9c1WAtt6MZ+pKqX8HPhJRLyhPnQ28D36bB2jvI/fXn6A/lvHj4GFEXFMRAS1j8cj9N86iIhX1d/+PrUXfm6lD9dRd6R5fxFYHhEviYjXAqcA30qY3wvVuXX06OL266h9W/Ug8F3gyvr4PGqvkn6//va47AvxbazlNGA38B3gC8Ar+nQdxwAHgLmjxvpxHRuAR6l9Qf9n4CV9uo57qH0xfxA4u18+HtS+UPwM+BW1M8P3jzdv4ErgP6m9UHde9vwnWMd76+8/DzwBfLnT6/B/RZakJP6fcJKUxABLUhIDLElJDLAkJTHAkpTEAEtSEgOsaat+r403TrDNloi4sMX4YET8xQT7DkfEp1/oPKWpMsCatkopq0op35vi7oPAuAGWshlgdV1EfCQi1tTf/2RE3FV//+yIuDki3hUR34yIb0fEbRHxsvp/39W4EXZEvD8i/qM+tmnMmeuZEfGNiPjBqLPha4F31G84/6E25rikPofjI+LkiLg3Iu6PiL+NiF929C9EqjPA6oWvAe+ov78AeFlE/A7wJ8BDwHrgnFK7W95u4MOjd46IV1O7R+5CYBFw6pjnP7H+XO+mFl6o3aXunlK78fwnx5tcRLy3vv35pZRfULvp/vWllD+iP28Woz5hgNULe4DT6zdkeh74JrUQvwM4CLwR+HpEPEDt5i2vGbP/24B/K6U8VWp3PRt7+8wvlFJ+U79cccIk53YW8FfAklLKf9XH3j7qGP8yyeeT2jaQPQHNfKWUX0XEXuAvgW9Qu5HRWcDJ1H7DyJ2llPeN8xSt7r862vOT2HasH1C7WdTrqZ19Sz3jGbB65WvAFfW39wCXAQ8A9wJnRMQQQP3Wkq8fs++3gD+NiFdExADw520c7xng2Da2+xG12z/eFBFvqo/dO+oYy9t4DmlKDLB65R5q12q/WWo3gP9fatdo9wPDwK0R8R1q8Wu6xltqv3roGuA+YCe12zY+PcHxvgMciogHJ3oRrpTyGHARcFtEnAx8EPhwRHyrPueJjiVNibejVF+IiJeVUn5ZPwP+PLC5lPL5Lh3rGOBgKaVExHLgfaWUpd04lo5uXgNWv/ibiDgHeCnwFWo3w++W04FP13/Lxn8Dl3TxWDqKeQasGS8izqX2Sy9H+2Ep5b0Z85EaDLAkJfFFOElKYoAlKYkBlqQkBliSkvw/D3pO/kkm9dIAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "sns.boxplot(x=df['weight_kg'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "87fb31fe",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Hay 42 outliers por debajo de 55.0 y 295 outliers por encima de 95.0.'"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "outliers(df['weight_kg'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "dd8a4206",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<AxesSubplot:xlabel='weight_kg', ylabel='height_cm'>"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYYAAAEJCAYAAACQZoDoAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAACK/klEQVR4nO2deXiU1dn/v2f2yTLZV5A9bJmEsAWs1VpxFxIQFHBBQeWt1ULVarV1DVgt/rRFaX3rgoIr1g2kal3at2oVEVRWZZFNQvZtksw+c35/zJI5zzlP8iRkA873urwkh7M/Dzkz932fz00opZCSkpKSkopI19cTkJKSkpLqX5IHg5SUlJQUI3kwSElJSUkxkgeDlJSUlBQjeTBISUlJSTGSB4OUlJSUFKMePRgIIacRQv5NCPmOELKLELI0XH5Z+OcgIWSSos1dhJD9hJA9hJALenJ+UlJSUlK8DD3cvx/AbZTSrwkhiQC2EkI+BLATwKUA/hZbmRAyFsA8APkAcgF8RAgZSSkNqA2Qnp5OhwwZ0lPzl5KSkjoptXXr1lpKaYbo73r0YKCUVgCoCP+5mRDyHYABlNIPAYAQomxSCuBVSqkHwEFCyH4AxQC+UBtjyJAh2LJlS09MX0pKSuqkFSHksNrf9ZqPgRAyBMB4AF+2U20AgB9jfj4aLpOSkpKS6iX1ysFACEkA8AaAX1NKHe1VFZRxzA5CyGJCyBZCyJaamprumqaUlJSUFHrhYCCEGBE6FF6ilL7ZQfWjAE6L+XkggGPKSpTSpyilkyilkzIyhCYyKSkpKakuqqejkgiAZwF8Ryl9TEOTDQDmEULMhJChAPIAbO7JOUpJSUlJserpqKQzAFwNYAch5Ntw2e8AmAE8ASADwD8IId9SSi+glO4ihLwGYDdCEU03tReRJCUlJSXV/erpqKTPIPYbAMBbKm0eBPBgj01KSkpK6gRXMEhxqK4VVQ43smwWDEmLh06n9qu28+rpbwxSUlJSUt2oYJDi/V2VuPW1b+H2BWEx6vDY5UW4MD+72w4HicSQkpKSOoF0qK41eigAgNsXxK2vfYtDda3dNoY8GKSkpKROIFU53NFDISK3L4jqZne3jSEPBikpKakTSFk2CyxG9le3xahDZqKl28aQB4OUlJTUCaQhafF47PKi6OEQ8TEMSYvvtjGk81lKSkrqBJJOR3BhfjZGLzkT1c1uZCbKqCQpKSmpU146HcGwjAQMy0jokf7lwSAlJSWlUE/fE+jvkgeDlJSUVIx6455Af5d0PktJSUnFqDfuCfR3yYNBSkpKKka9cU+gv0seDFJSUlIx6o17Av1d8mCQkpKSilFuogVlJXbmnkBZiR25p9DBIJ3PUlJSUjHaWenAX/5vH6776TAQAlAK/OX/9mFYRjwmDUnt6+n1iuTBINUvdaqHC/alTvW9r3S4cbjOhb/8ez9TXuU4dXwM8mCQ6neS4YJ9J7n3QE7YxxDrgLYYdciynTqmJOljkOp3kuGCfSe590BBbhLKShU+hlI7CnOT+nhmvSf5jUGq36m9cMGeQgBIhST3HjCZ9JhZmIth6fFRc1phbhJMJn1fT63XJA8GqX6nLJWv8idiuGB32+uPpz+vN4Dtx5pQ6XAjx2ZBgeCX3fHuvZYxOlPP5fJhR6UDVQ4PsmxmFGTbYLUaNc3leGQy6fu1o1mm9pQ65RTBCivt3N2JFe4Ndbe9/nj683oDeHv7Mdy7fme0bVmpHTMLc5lfyMez91rH0FrP5fLhnZ2VuHdDTL0SO2bYs3vlcOiv6g0/EKGUdktHfaVJkybRLVu29PU0pLpZkU9EPYUV7g0dqGnBxY9/yn36fnfJmV0yyxxPf1sO1eOqZ7/k2r543RTuk3FX917rGFrrbT5YhwWrN3P11i4qRvHQtA7nc7Kqu94rQshWSukk0d/JbwxS/VI9jRXuDXW3vf54+qtUaSsKwezq3msdQ2u9KodHpZ6nU/M62dQbfiB5MEhJ9ZC621ei1t+AFAu+OliHSocH2TYzCnKSYLGw/7RzbBZMGpyEBT8ZBpfHjzizAWs+P9CtIZhax1ALB822WXCgpiVqN89JMquEjZq7bc4nonrDBydNSVJSPaTe8DGsvW4SDtW4OTt8SUEOczj0hr2+xeXGuztruDEutmcgwdr2S0vNx5BlM+F/Xvg6WvbE/PFodPpwz3rpY4hVd71X7ZmS5MEgJdWD6m5fibK/uhYPrhbY4V9YVIzJMXb4bT82YO5Tm7h66xZPxbjTUro8n1h1xicQiUqKfDtITzDhwpW83fwfN/8UdU5vr0cl9Xd1x3slfQxSUgL1BvpBq71e61wcHg9qWzyoafZCRwiqHB6kxJlw6YSBIOHqb2w9iganjzHL1LWK7fX1rR6mntq4WsJG1XwCdS0ebD5YF207NjseBARBShGkQJBS1LV4MDIzAdefNTxqhnr6kx9Q3eJBls2CQJAiPcEMs1n7ryy3248dFU3tmtjU5PcHsauiCRVNbuQkWZGfY4PB0H/uA8vUnlJSPaD+hH7QOpdGlxsfKEw1r1w/BQtOH4yVH++Llv3uotFo9fijkSsWow4PzSrE4DQrDte5ov0NTrOi0enHjS992u64Ws1QWTaxT8Bs1Ee/SViMOqyYXQhvIIi732ZNSb84ezhufW1btOy+Gfkw6QmzDq3PyO32Y8OOig5NbCL5/UG8va2cmd/ymXbMHDegXx0OPalTY5VSUgr1J/SD1rnsrWyN/qKL1HP7g9FDIVJW2+rFXW/tYMruems77p2ez2Ae7p2ez9UTjbuj0sGNe++GndhR6WDqpcTpUVbCjvHgrAI88M4upu3+mpboL91of+t3IhgEU/bAO7vg9Aa79Ix2VDSJ51zR1GHbXRVN3Pzufnsndmloe7KoR78xEEJOA7AWQDaAIICnKKUrCSGpANYBGALgEIDLKaUN4TZ3AbgOQADAEkrpP3tyjlKnpvoT+kHrXESmGlFZkELY377qFqyYMw4urx9WkwH7qlq6PK4obHRPlRPfHWvE8wuLUdPsRkaiBU0uH/Mtpb35tXr9XFm909vh/ESqPI5Q14om8fOobHJj3GkdNj8p1NOmJD+A2yilXxNCEgFsJYR8COBaAB9TSh8mhNwJ4E4AvyWEjAUwD0A+gFwAHxFCRlJKAz08T6lTTGohfwNTLYw9vCDbBqNRr8neLLJL63SkQ9+B2lzS4s3Ycqg+io0QmWpS441cmZ5A2J/T68eSV76Jli2dNkJT2KOaiUgZNppjs+Bfe2sRZzGDEGBPVQvOGZWheX7xJvbXkcWoQ1aiGY/PH8+Ev2oJy8xWmfOAZAvnU/H7gwyeIzfJKg6nTTrxkCxdVa9GJRFC1gNYFf7vbEppBSEkB8D/UUpHhb8tgFL6ULj+PwHcTyn9Qq1PGZUk1RWJ7Pov3zAZ+6tcnF16cLoZ16ze2q69Wc0unZHIhmCKbOSiuTx6WRECNIg7Xt8eLVu3uBh7Kp3M/NYsnIjDdR6mbMXsQgQoxV1v7oiWLSu1w2Y1YOmrbWOsmFMIPdHhtr+379todrnxniAM9SJ7BhJjwlBFdv2HZhVAryO4443tzPxEPoYkiwFL133bfr0SOy6xZyLe2v5dBtFcVswuhF5HcNvft7W7zyvmFMLrD570PoZ+Ea5KCBkC4BMAdgBHKKXJMX/XQClNIYSsArCJUvpiuPxZAO9RSl9X61ceDFJdlTLkr7bFIwy3XLOwGHOf2sSUKcM81cJB/9+ccbg55lO6GrpAOReHy4d5T/P9vb/0dFQ3B6LfaIx6gl+v+xbTCwdEs41t3F6O3188FtuONjFl8yYPQosnwJStWViMIEW7YY9fHazDb17fxo3x/+aMY0Ji1VAN62/6CZpcfi4qaVdlS7QsPzsBBAQ7K5ujZXpCcKUAnaEViRGJSor0l2w1YcZfPuP6W3zWMDz+8X6mbN3iqQCAyiY3spMsyM9JOqkOBaAfhKsSQhIAvAHg15RSByGqEQWiv+BOLkLIYgCLAWDQoEHdNU2pU0zKkL9dxxyqNndlmdLerGaXFtnNRTZy5Vw2bj8m7G/XMScuKcyNlr2/s0KYbazB6eXKWr0BrqzS4cbUYent2uwrHR6VjGYexc/iPWhw+jB1WDrXb/FQ/lN/7C/8d7aJ90ArEsNiMTAH1xc/1Ar7Cyp+w7h9QRxtcOGSwtxTxqegVI8fDIQQI0KHwkuU0jfDxVWEkJwYU1J1uPwogNhHMRDAMWWflNKnADwFhL4x9NjkpU4pqdnSlTZti1GHQWlWbPuxIepPULNLi+zmWmzkOTYLzh+bjiunDkVDqw+p8Ua8uOkgj5dQGTfJYsRNPx8RvdvwzrZy5GfH49XFU1ET/nbw4a5yZCVamHWI/CfZNjMun5iDmRMGobbZg4xEM976+giybKwPJD3BjMFp1ug3i8i4afFGxm8zJjseeuiYbwf27ERYzEbGHzMgWQ2xYebm7PX5uf4ICHP3Ii3eJNwrZeTrqZatTaSejkoiAJ4F8B2l9LGYv9oA4BoAD4f/vz6m/GVCyGMIOZ/zAGzuyTlKSUVUkG1DWYmds6WDBKK/UCxGHVbOK8LO8mYG1fDInEIsn2ln7NLLSu0wGgjTdvlMOwalxHU4lzFZCTh3TC7+54WtzFzGZrGf7EemxwvnTHTAs58dYMb1BQmufW4zU6+iyYlFa9r3n4zOjsekIRlY9PxXTFuTgWLuU239PXPNBNx0dh4zl2WldnxX2cLY8EV+G5H9//9dNg4LTh+KO17fxrSNMxHM+d9NzLjHGrzMuE9eOR41zT7Ox/CHWQX43Vttvpc/zCqAQcc+o7ISO+zZtm5/v04k9aiPgRDyUwCfAtiBULgqAPwOwJcAXgMwCMARAJdRSuvDbX4PYBFCEU2/ppS+194Y0scg1Z0S3fCNRCVF7M2UQmj/f+MXp8MfpNF6yXFGLFi9mbPNP3dtcbdhsrccqsdtf+d9DKVFAzi7uciW/ty1kzH/6S+ZMqX/RA11oWy7dtFkLA4fZB2Nq/TbLJk2Ak99ckBTW+W4r9wwBQvDh1ZHc3nu2kn4bH99dK+SLHq8tPlIl57Ria4+8zFQSj+D2G8AANNU2jwI4MEem5SUVDuyWo1Cx+a401Ki9ub3d1YIbdVHG1y4wJ4TrffFD7VC23x3YrIrHW7hGCK7uaistsXDlSn9J2r3GJRt61t9mm34Sr+N2t0GLXOuaebnpzaX6mbW93LzOSO6/IxOZkkkhlSvqrv5RKIUkQA0pY0UzSUYpNxdBABM2YBkq9CWroxzz7JZcP0Zp+Hc/AGMXT/bZmFs8wW5SXAFfNhT2Rr9pjIiM05oDx+cFsfY6wenqcTcJ5q4+H9RWV5WPF5bPBVVzaE98Ae8SE+0MmNk28xCf0dOkgVrFk2OlllMOuG+iGz4p6VYsW7xVFSHx61xuDXb/09LsTK+kniznhs3yyb2J6TEsXwntTsVGQkd33coyA1FKvU0b6svJOmqUr2m7uYTifDNT141HjUO1rYsShspmsvfrp6AmmYv4yd4cFYBTHqC22Ns5GsWTcThWk+HeGmny4uNO6u4eklx7H2ClfOK0OT0c/UybEbc+OI37dZbPtMOk17H3BNYOa8ITS4/sy+iOwHLSu0wG3Wc/X/caQko/UubDf/DW0/HF/ubO5zfijmF8PiCLCZbdD9BcE9A692GlXOL0OTueG2ifRHOWeDbeOzyIpgMBDe/3FZv9bUTcbTBw6HCB6aYsej5rd3yPve2+sU9hp6SPBhOHHV3qkuRHV7Ntqy0zYvmsmr+ePwm7OiMbau0c4ts2qL4ejXbvPJug9q4axcVo9LhiSIsUuOMuH7tFq7e0ml5zP0Ee64Nt8Swl4DO2fDXLizG5TH2/9cWT8WC5/h1PHX1RCxY/VWHYyjnl2DWM3ynSL3H543n7l48dlkRPIEQoTUtwQyDjnB7qjbuPZeMwcDUODQ6fUiOM+KlTQcxaXAamtzsXY6Vc8fDZjVG73LoCDgEuNp7pdyD43mfe1t9fo9BSgrofj6RyA6vZlvm00a6OVy10xcQto0z6ZnQz5oWsc29ppnFS4ts325fEAEaZEwwzW6/sJ7L60dmohk1zRSZiWY4fX4hYntYhhVJVkvUtNLQ6uX6C1II2xp0OmZtb2w9iia3jzHzqPkYnN4AY5pqcIoR4L5A24dPQkL/ifoT3b041uTCr175NvrzE/OLhGsT9Vfh8OD3b+9iykdmJ3NjNLm8IARodPpgNRoQpEHhe6WGN1eOq/V97g3se1clDwapXlN3pyQUpYgUsYNEcek5SRYOV/30gklc28FpViRajPjzR2311i4qFo4RZzYweOn/vWqisF6i2ciEoT44q4BDYk8anISqZi/uXd+G0ygrteOWc0fg3g2720wXlxWgyRnE0lfbxl0+k+/PZtZz6106LQ9jcxLxPy+2jXHreSPh9gXxq1fa+nt+4WThvrR6A/h9TOhnWakdN/18OJb/47t2x7h3+lhufmp3PnKSrExZpuCZq/kJchQsJ5HPIrLPsfNbVmrHpMFJ2HK4jaaak2QW7l+2YAwt73N/wr6LdHLd8Zbq1xqSFo/HLi+CxdiGZX7s8iIMSYvvUn8FuUkoK7Uz/QVoEGUlbFlZqR2FYad0RIEgOFz1yo/24AEFNvq+6flYtnE3U+9AdTOWTstj6t0zfSzuV2Ce79uwE/dMH8vUW1ZqxwMbWQz179/agTsvHMPUWzptVNSeHal37/qdiDMZmbIEi4nDS9/99g7cr9iDUTk2fr0f74NLgbV+7MO92FfdzJSt/uwHDqd934z86KEQO7/qmG9JamOUbdyN+2aw/ZWV2OH2+xV7kBf9pR8ps5l5tPfwzATcfsEoru2o7ESmbPlMO0ZkJjBlt5zH7/M963fitvNHM/UIIcL9I4R06X3uT9h3keQ3Bqlek05HcGF+NkYvObNbUl2aTHrMLMzFsPT46NfxyAEwLIMtU0YlVTfzZqgth5tQUhRg0NR7BWjqo00evLH1KK776bCorbrZzeOlD9e50Oz2MfVMesLVc/tCSOzYehUqZjclYkPNdOb0+Jl1tKiYq5rcvClEGSL6we5anDs2G3+7emLUXi8yV4naqo1xsKaV6a/K4cKjH+xn9mDtF4cxMCUO6xZPjd4N+aHWiU0/1GL1tZOjfgeP34+H3j3ItT1N0TY/JwnBIEXuddbou1GrYu5rcvnwbsx7ureqWVivvtXL1NP6Pvcn7LtI8mCQ6lV1d0pCnY7AqCfQ6wiMeh10OgKfL8CkjQwEgnC7KZPmMTfZgsfmjMXAVFs0VPNonQOHGry4d/3uaP9Lp43gsAy1LW6YDG3/+AkJffUWmTNS44wYk2OL+hMopcJ6Rj2Bx9/Wn81iENbLtpnx8g1TomgKgx7CENEcmwX+IEVVM0WWzQydirklLZ4PYU2NM3JlRxvcuOP1ndG2q64YL+xPFF4qMhGlxRthNuihIz5YDHqY9TrOx2Ax6jA0PQ5ObwDeAIXHH0R+Thye/68TtS1euDwBAF6kJRgxINmMUdmJ0TkPSDZHseChsyo0sUAgyLwbg9LF4b45SRbmPW12+1XMVRbUt3pR2+KFUafDwCSrMDRaqe42q3a3ZFSS1AkrEepahHkWhWWqhYiekZeIaY9+ES37x5LTsfUQG6opColdVmqH1aTHb2LCHp+YPx4NrXw9i1HHhL8+OKsARsWchWGZojBPQYjoslI74k163Bozl0fmFEbNJO3tS1mJHRmJRtz40jdsmSLMUxSyu3ymHSYD319uignXr/maKRueYcGVz25pdx2iPRDhNNTCh0dlxzHIDlEYb1mpHUkKHHlnsOrcegWh0SL1Bx+DDFeVOimlhroWhWAqy9oLEU1PMLeL4lZru2bhZHyyry5qzvjZyHRhuOqz10xCXasvauaJN+lwUzhmPrbe3RePhi3OHK2Xm2ThwnM7E4Z667l5TKhmkkWPxz7iw0ZFqPCnr56ETQfbUBI/HZGGRz/4PvRNKjy/xlYPnv3vQQ4vceeFY7DzmIMpWzF7HIcyV85PFHYb2mcWp6EWPqysp/bcXlhUDJNB1yFiO5KIKVIPgPD9U4ZGq0mJWu/tqCQZrip1UkoNda0FB9HqEdvcqxweFA9NaxfFrda2utnDmEJGZycI69W2eLH01W+jZX+8tEBYr7LZi7tjzFqdCdUU7YHDE+BwEFr8GG5fKMVmbNtRWQnYcrgJWw63HSBqeAmH2ydETnQ0P7V9UbZVCwtW1lN7bpUOD2aM6xixbTDoGDSKGhpdGRqtpu42q3an5MEg1S/ldHk5jHKc1cTUUUNOi+3c7F2EpDi1sFY+nabShp8UZxTa9QelWJn7CfEmsZ8gM9HE1FPzOwxKYZETcSa95lBN0R4oy9Ta2gTI7tNSLczdBrOeaJ6LqL+sREuHyI54s07V/h+LxDAK5iKy18er+G2UKUq1ShQuHeqvf/gJjkfSlCTV76SGkphuz2IOB1E9kQ1fKzairMSOsblxmPO/bXZpkf1aK5pCiOcQIDG0+kBEdvjH549HYys/Rmq8ETe/8k27Y4j8DiIfg9DW34lUnCKfhdLvIBpDNGfV5yvwbYzKtmLuU191+MyVKBOtEiFZtPoY+oOkj0HqhJIaSkKJnFBLOfnYZUXwBSlqmt3ISLSgutmJO17fyfVXVjIWWUlWBplQMu40xr4usuFrteuvmj8ej3zwvSYk9p8vL8KOGDv81KGpuOEFHn/x1yvGo8UbjNr1s21m3C7Yg0fmjMN/9tYyZfdNH8u0zUo04ZF/sn6CtZ8fwE9GZGjyxzx7zST4g5TZv7PyMhm/iKg/kR+jvTFi/TGNrR784b3vBXb9Yhxr8jDj3n1JPghpS8+pIwQPvLOTW++dF43V5BMQKQJxbC80ur9K+hikTiipIRiUKR3VUk4qMQpqtvQjDW7c8cZOpnzamBzmZ5ENX6tdv9Xj14zEblLY4fMyeX+C2xdETYsXv31jR7TsiflFKmk33VyZsu2f5xZxfgIAmDo8g1uHFl8JEEJOxPpFRP2J/Bhax1B7lhVNbiyJeeZAaA9iMegbtx8TrlerT0Akk0nf5UOlP0seDFL9TmopNpW24GyVeukJbL32kAmxNvwXNx1ESpyJsYfbzHrhPQYtdv14i0Ezhjo3yazwT/Ao6Xe2lXN3AjITtcXDh/aFteFnJJqEqTNtZtYfk5IgRlhnJpo434EI7S1OnWlm6lmNYn+C8p5FbYtbuC+i9Sox6Dk2i0qK0hPfJ9DdkgeDVL+TPTtRmK7Snp3I1CvISRLW0+vbnLkWow5ThqVgQDJbL3LfIZZZtGJ2IVo9fiYl5oOzCrj0kivmFGJZqV2Il44dN8dm5FJdRnwMsfVWzitCRZOXQ4X/7qIxjA2/rMSO5Hg909ZmJcI9SFXUWzG7EA1OH3fnQ7m2yH2Mx2LuQCyfaceK2YWM/2TF7EJUNHm49KEmvY5LxZmbYuLWW93s5e5oKFOjhtKqBpn+Vs4twk0/z+P8BBYjmDHKSuzIS2fRFKOzxClKx2R1DclyMkv6GKT6pbREJQGA2+3HjoqmtlScOSEbb2x8eLPLhyXrvmHs8GePSsfVz2rDN2u5E7BxezmuOX0I0hMtUft1RoJJGF+v1Z8guk/wp8uLmDsBPx2Rhjvf3M77GGaPw3/2tfkY1FDXWu58WIw63HHBKGZttc1urPjnHk39rV1YDD+lUYQFQLHoeX69f7liPFpjfCBrPz+Aa38yrEOfT+jAGA9PgG372wvHYLLCJ3W1wHf1wqJipt6pIuljkOqyuhsNLOrP6w0wuIqCnCT4wNqRfQiixeXG7pgsZ2Oz42EgoVc49uON2+NDbYsHNc1e6AiBLxBAaWE2zshLj4Zbevx+3H1RHkZmp0SRGFUOl9B+nWRhERFPf/IDLCY9spPjomWf7jUiwWJAeoIJtc0UGQkmNDjFPCGXL8DgG1q9fozMTMD1Zw1nxgiCcuMmWnU4My89GqpZ0yL2s1Q3e1A8NCVqmtonYD6J/CJqZfVOH8o2fhctU7P1i9q6fH5YjaHnZNARtHrF/gSnNwCAADQEsPD6KeeLUPPvuHx+pMSbEAxSJFsNSDQbhT4pUdvqZg+Xra0/EE7bU08ju+XBIKWq7r62L+rvifnj0ej0dYhqWDG7EL4gZTDPWjOGrZxXhIGpibjmubYw1CevGg+T0RxNQBMyhfC46sFpViTFGRlzxgMl+bCa9EzZH2cXwOunjJnib1eLsdupCSbGhPXoZeNw5dTB3Bh6wmYWWz7TjvoWP+54oy3M8ymVMdITTbj2uba5PHnlBE1+EbWyVEVKzBwV/068IiJHDR+uxFoPTrPC46e4++22Z37fjHzOr6R6V8LKoswfKMnH8Iw4pq2aTyrObIgmbTred7w31Bs4DYndllJVd6OBRf3tKG+K/mKPlN2zfif2V7cwZftrWjjM8/7qFq7tvet3whegTJnPTzk0tZ7ohLhqJQ763un5Ubt3pN59G3Zx8/uhppWby54KB4fnXjotD3sqHGy9qmbct2EXN8aeqmbF/HZifw077vcqY+ytZNve/84uDgF+34x8pMebOiwL5VSwMWUjsxOF4xYMTGLKbjlvtBAfvnQai8m+88IxuPtt9vk+8M4uGPU6pt6gtDjcet5Ipuye6WPxwDv8/jV7Asz7Z7PyyO7lMws4XHp/wl+L1BvIbvmNQUpV3Y0GFvWnNfSzM2GjWkIh1XDVrR4/g29WMwdpmZ/DE+Dw3Gu/OIzZEwd2aQ9EZVrHECHAm1xerPn8cIdla784jPQEM4sFb3Jj7Rd8vbsvGcPgtOtV8NyVDjfTdl+12NR1rJGtV9Ps4eYnQp67fXx4875qHtl9uLZF2La/4K9F6g1ktzwYpFSlhgbOtlm6ZJMV9acV6SCqpxXBkJLAh2WmxhmFoZoZCWbQbNIhlkE0P2UYZYJJL0RJa0VTiEw6ylBSrWNYjDrEGfXIjfGLNLR6OFx1Q6tH2F9mogmZNnPUZ5EcZxTWy0gws/mi/2eqcG1Wo55pu3TaCM31lOOqtVWaoXJsFry7qwpvflvRYduMBP4dDwYpdlU0oaLJjZwkK/JzbELYXk+rN5Dd0pQkpSpRxrVVV4zH7opmXPz4p5j/9Je4+PFP8f6uSgSVH2U19mcfkBTFHETKlpXymbaGZyTgD7MKmLIRmQlc27JSO3QEePazA1j1r/145tMD8PgCmDs5ZMP/7Zs7cPvr20BJEJdPYsvmTh6MmhYPU1bf6sOKOYUdzm9srg03nZ3HjJubYsXymRrWJljHslI78hT1VswpREq8mR0jWTzGqCw2e9kjcwphNRmYtaXEm7h9sZoMeESx3kfmFKK62Yv/eWErfr3uWyx+YSu+r2jBk1eOZ/e+xI5EK5vRTE8EGfVK7DAZdR3uQVmJHfEWRb2MBDyo5T0QhTcLMv4Nz0zAo5ex7+RjlxfhYF0L845/ur8ab28rx9ynNuEXL36NuU99gbe3lcPvZz+594a6OxOiSDJcVapdKdHAlAKXPPEp92nl3SVndioBeixqOBKVFIk2shh0eGDjLg5dcM8l+fD4g6EookQLTAaC5f/YzdSzWfT4RTh/b0SiEEc1BIMo3PKvV0yAXk+i5hEdKF7YdAhXTh0aLfMHgkJ0tiis9criQVzZTWcPZ/AcNQ4Xnvj3D0wYqlrIqSjM87cXjcH/7WkLVy3IteHXCoS1WujnE/PGw+Vv6y8t3ojr1vDhpc8smIQAZZEYC88Yjs/21zFre3bBBNS3BqLPLS1Bj9++waIpHE4P3v62nHvm08Zko8XD7tUfLy1EdYuXqffQpXY0OAMdhjeLEBYGg455J3UEuHDlp5rel3WLp2LcaSkdvvfdre5AdstwVakuS4kG/uKH2uOyb4pQwxaLgYkjf2ebGF1wpMHJoC4en8cjHUSoZpENXw3BILLr17R4GJTEHy8twAe7a/HB7tp2x3X7eJQ0AGGZEs8hQlirhYjWKlAXQIgP1BHCWs23Ue/k0RmienWtPBJjxriB3Nq+q2zt8LndfM4IVTwHh/to9nDjHqhx4QI7izMRSQ1h0dE7rorsbnJ3iOvuCfU0slseDFKdkpp9U2ST1foJJpIAJWK7HZhsEdr/R2TG47XFU6P3DhIFuAqLQcfZ+m1mHi+hht0W2eaHpMcx45qNBNefcRrOzR8QvU/gCwSE/Q1NszKpON/6+giGpFo4FMfx+FREqTMHplg7RE6I/CIi7EZqvHivREiM9AQzVzY4ld0/tbkI/UUKn8o728qRogidtRh1GJxuxVcH65i7MJGLjrHvJACuTOk7yEww4+6LRqDwtPTonCkNiv1tSdrs+qJ7Bx6PHzsqHW2XM7NtsFqNHXfWC5KmJKlOSS2G2mQguPnlb5gyLXHVopSJK2YXAgCDYFBDRCsR1s8smIBjjd4OkdhrFk7E4TpPh+k5RXclRP2J0m6qpdO0GFlsdFmJHbnJJly/9mtmD5QIa+G9DUHazZVzi+Bw+5l6ov7U0psqcdXPXDMBxxrYPRXdKykrsWPcaQko/csmZi6i9JzK5yZamxrGW5kWVA09PiTDggUx9VZdMR5eP2Xe3UcvK0KQBpnn8fovpmD3sVb+3TDqo+akyHugTAGq9d/M6msm4mgDn450hj271w4Hid2W6lYp7Zsim6xWv4PW9Jxq9nCt+GZlf2sXTcY963dyKImHLy3AZ/vr27XNq/kiHp83HtuONkXbnj4sFdev5W3zorbK1JlqvogbfjqUw1or7fBqKTFfuK4YFTFo6mybWRVv7g+2ISxMOoKnPt3P+FSO1jux7B/f8W0XFjNRSWrP45kFk1Dv9LWbFlTNp7J2UTHMMak4vf6gEHXx3LWTMf/pLzt8h5TP47XFU6MXH5n905gCVKkDNS3RC3QRrV00GYvDF/KUayvuJTxHn/kYCCGrAUwHUE0ptYfLxgH4XwAJAA4BuJJS6gj/3V0ArgMQALCEUvrPnpzfqazuuFIf+UxR0eQWIh3qW0Nx5O3hL5pc4vsEShPMoVpxnLsvEGRMJt5AEClxJlw6YWDU/PDG1qOc76C+1aeCkvBG/0wI0KKCbxD5IpRhlGrobFHbRpeXCRv9dK9RiN2I9sZgI/iUmKI9aGj1MciOapWUmFUODygAlycAILQfSp+Kmr+jutnDPA+3P6DJP9EZn0qVIhXnO9uOCddb2+Jl5tLgFK9X+TyqmsX3BLSmAFVKdO9A7R6N8u5FX6mnfQzPA1gFYG1M2TMAfkMp/Q8hZBGA2wHcQwgZC2AegHwAuQA+IoSMpJQGINWtOp4r9aK2L15XjPlTWKTDQ5cW4FijG1c924acePSycQgEKWOC+dtVPNLh/LHp8AUIg5cQ4SosRh2S4oz45UttJphnFkzEgtMHRz9pWoyhG7l6xbKybGKUdE6SBb+Nmd9zCyep2PVZ9IPI1q9mmxf5MRIsRtz4YhvSoawkP4wF2RbzjMahxe1nyu6bkY9AgP0nkpJg4vbgdxeNRovHjyWvtpmc/lew9xajDlmJLCrkuYWTNfsE0hJNWBiD4lh9Ld/WYgzhtGOV0Im0pdmK+wmDUq3CZ56dZI6CEi3GECZDieIQPQ81P1pXU4CK+lN7N7o6RnerR+8xUEo/AVCvKB4F4JPwnz8EMDv851IAr1JKPZTSgwD2AyjuyfmdqjqeK/WitjXNXg5JcLC2NXoARMpu+/s2Dumwp5JHOiw8Y7gQV3HPdBZnIEIh7Ch3MOYHty+IlR/vwygF0iHOZODwF/fNyIdZr2PaGnQ6IfrBPoDtr6zUDp0OTFmQUg7BsKzUjsxEM7cOJZbh3g278ENNK1MWDAL3KtAZD7yzC0Mz2PsOBkK4Paht9eJ3CqTIfRt2YvlM9k5AWUk+4i3sHuyrbOb2IC3ehAcUa1s6LQ/7FCiOA9XNwn2ON+uZMvuAJOEYyrsr983Ih0VhvvH5g8Jn3hjzqTy03l247fzRTH+PXlbE3RcxGyC8ezEmu2v3BET3Dgw68RgF2bYujdHd6ouopJ0ASgCsB3AZgMgXswEANsXUOxou40QIWQxgMQAMGjSoxyZ6sup4rtSL2joE5iCtmAcR0kHNxNHo9HaIQmj1ik0XzW4/g0I4Uu/CK18exoo546J27mc++QE3nDWMaVvRKEY/3DN9DJ5fWBxNH+ry+fCnD/Yx/TW7/RyC4Wi9E3/59w+akA6ijHCitSmxETuPOTQ9j8N1LqTEG5h1/HNHOcxG9ttQdYuXe0ZP/ucArvnJ4A5RHJXNXnyyp5rb58U/G87sS32Ll9vnJ/9zAPfNGCt4RsNREHN3oEKFmlrv9HJlTS4f3l1yJhP/HwxSDEqNY3wHw9LjMSS9OBoxNCY7HoldyAsNhEJLL8zPxmjFuB6PH0PS4/plVFJfHAyLADxOCLkXwAZEjJghk6lSQs84pfQpAE8BIedzT0zyZNbxXKnPsllw/th0XDl1aDTcUq8DV1bR6NRkRtETcLb5tYsmC8MoLYaOMQpq5oesRHPUJ2LQEQxMtqDJ7cOeyuboGE1uH3KTrEx4ZKbNDJOhbdKEACYDwWkpcWFMNKAjQIrVgL3VLVgS6wi/Yjy2/tiInJT4UH9VLUgw6bn+dNCGxIiPSQQUW08LXkJtX8x6PT4N523YU9WCf+2txcXjchnbfJNTjMlwKnwbas9XtM9p8SbGMbx20WThPieYDah3+qI+FZOBcOYWtYx/ojDenCQLF/+v0xGMOy2F8R0kGiwoHtqNiAnBvQOr1dhrjubOqtcPBkrp9wDOBwBCyEgAl4T/6ijavj0AwEAAx3p3dqeGIl9tlT4GLVfqcxMtOHdMLoM4XlZqx/RxA7myFXMKGXR2BKcd+UdsMbYhDmLDHlPj9MLMZznJRqZtBIUQG+I4XFC2fKYdFU1uLvz15p/ncaGklQ43k5XszLxUbi7LZ9oZU1lkfmsWTcQ1q9v2IFmwDlEGMlGGNFFGOKOO8JnjSuwwGgi7p5kJXDY00V6VldgRCAaZ9a6YU4hDtS4OZb5ybhGXTS7Dxj4PUXa6sbk2DEiO6zDDXLyZCJ+5MoNbWYkdIxUmndHZ8cIsdsp9WT7TjvycpJ76Z3VSqcfDVQkhQwBsjIlKyqSUVhNCdAg5p/+PUrqaEJIP4GWE/Aq5AD4GkNeR81mGq3ZNXb1Sv+VQPa569kvu05koBFOZqWzj9nIsL7VDr9dFTQhvf30Evzp3JCobPdGv1BQQhlE+d+1kBreQZNHjg92VHEbh8kmnMXiJRJMBVyjmrDV0US2sUJipbFExghRRs4yegAujVBt36bQ8Dv0wb/IgruyBknw43AFmvb86Jw8gRIGmGAqKtn226HW45e/fcuG5t58/WlOGNGXmuNCzLOBCbJVzVgv3XbuwmMkw15ksdsqQzgM1Ldi0vxIjslKi2I39VQ04Y2Q2Gp2+ToeXnirqy3DVVwCcDSCdEHIUwH0AEgghN4WrvAngOQCglO4ihLwGYDcAP4CbZERSz6mrV+orVfwTohDMJrePCwc91uTm8A2XThyEqcPSoz+/s+2YcIzaFg8XzqiGUYjFSzwxnw8b1eoDUQsrFK23yuFm0A+dGVcZcgpAWFbl8PD4C0HZtDE5TNkT84uE4blaM6Q5BM+yXmFeEs1ZDRVS1ezWFNqrnF9on9mQziqHG79bvwdKvbo4GVOHpfcJsuJEV48eDJTS+Sp/tVKl/oMAHuy5GZ380no/oav3GHJU/BOiEMzcJDOHfhipwFr4A16clmrB5oN10W8MOUlmIRJDiVuwmfWcb+PFTQcxcZAN6xZPjabxNOqIEImtZR1qYYXxJh7VMCDZyqxNhOfQOq5aWY5gT9MTTIxPYM3nBzAkzYpXF0+NIjviBViQEF7CxO2p0EdjM3NjiJAYWv0iOTYLc0/FbCQq+8z7CXgfA+/3enHTQaHPrKdTYp4skqykk0ha7ycczz2GvKw4zp4r8h2snFeEiiYvZ/dtdPtYfMO8Ivx3XwNT75kFE6JI7Ni26QkGxh7++LzxSI4zM76NFXMKUdvixz3r29a2fKYdt503ivMxKG3uy0rtSDCztm+zkXDr/cOsAhh0hEVizC7E4Ton7orxlSwrteO280dxKUofvrQAd765g5mfSc/uXwSdwezp3CJUOrwcXkKnA7NXK+cV4XCdm0NY/OqcPMbvsKzUDo8/wOypyDe0cm4Rqpv5cZs9bNuyEjsGp5vx1CcxvgOTTvi+VDjcLBZExY8RwW6352MQ+b3KSuzIVRwMvZES82SRRGKcRBJdvbcYeTSF1noibT5Yh2cUeISXNh3EkmmjouaUEHSMCjEFT109EQtWfxUtEyET1DAKWnALWn0HFqMYif2ny4rw8Z4axva98uM9jB8j3qTjENudGffl66fA7Q+22f8NOtzyGm//v3f6WAannRpnFCI2tOxpZ+a3av54OH1t45r1OixdxyPFRfZ/pR8owazHx9+xfqDGVg/+8N73mvwY15w+BOmJFsancseFYxgfg5rf68XrpjAk1eN5709GSez2KSKt9xOO7x6Dh8MjAMCMcadhxrjc6M9qfoIGp48pE8Xmq8XrVzW7O6zXmTSZIvx1eZOLs313Fe2tNm55o4vzRYjs/0qcthr+WsuedmZ+da1eDjOu1f6vxQ+khroQ+zF8KNv4HVOm9DGo+b2qHOz70hspMU8WdepgIIQUAhgS245S+mY3z0mqi9J6P+H47jGYOeT0h7vKkWUzM9httdhyJTJZZINWs0tn2yyMnVuUdlMtXj81zsjb4QX468GpcYxt3qjn+xPNrzPpObOV9nWBL+KdbeVcitK0BDHGIy3exKUy1To/ka9EadePtxg04bktRh3SE1j7//Hiw0X7J0rZqfa+xL6TmYk9nxLzZJHm2K0wEG81QgiLGeH/pvfQvKS6IK0p/44nNeDI7HiMzE7Btc9txq9e+RbXPLcZI7NTEGciTCrERItOeOU/EAwyZREbNFNmFrdtcPr4tJuzC5l6Y3NtfNtSOwYkW5m21/wkFM4Zm65y+riB2FPVwqxtf40TK+exe2XUE2GKSC1pPMtK7HB6/Vj0/FdY8uq3WPj8VzhU58Rt541iUnbedHYeUhP0TJlJT7m1LSu1o9HlY+o5XPy+iFJiPjirAAOSrdy4yfF67nko05bedHYel3Yz5O8IcuM+pBhX+IwEaTzLSuzIz7VxZUofgyhlZ1mpHS1eH/NOHqxr6fGUmCeLNPsYCCG7KaVje3g+nZb0MbDSej+hq/cYNh+sE94xWLOwGHNj7P9rF03Gxm1HMXPCoKgtnSCIO9/cyaGVX/3qCFNWkGvDQ+9/x9ncS4sGdGgPz7aZcfvr2zpsK7K5q9nhn184GdXNXiYN5Sf7qhk/S1WTC69t+ZFLM3rfhl0d3h1Qs/WLfAfPf35Ak73+2WsmwajTReP6nT4f7tuwm5nLuIFJUahebFulrV/tLoLonspdF47hyv50eRGONrqjc7YadFj+7m5uX0T3Nv4wqwB1rT7Gx3DnRWO5LGzKlJ3pCSYhCv79pWciSHFcKTFPFnWXj+ELQshYSunubpqXVA9I6/0ErfUi/+AqHW7k2CyoUuHS1LZ4GJNEqyeA17ZW4LWtFdF6f7y0AEkWI4OXrna44fW3fTiJoK6VZV4/RZzC7PHG1qPwBYIMSrrR5cOwtHgUD02Jmoh2lzdiYAprNqp0uDTb4ZtcPmQmmlHTTJGZaIbZQJFgMsKo14UwDXodLCad0BchWkeABrl1CH0gbj9j/gqCarbXH2t041CdM4q6SDDrOT+GGp5baetX8zGI7qmIysobXVgS41P546UFKncqeJ9PbQufPlTpOwAAg0GH1HgTfIEgUuNNqGgS+xNqWzxIjW/DowD8O16QG8r+diqrMwfDGoQOh0oAHoTQJZRSWtgjM5Pqc3m9Aby9/RgTpvjidcVi+7CZDSV9cBaPyc5KMnN47uUz7bjxZ8Oin3qjn5QVGOVbzxuJtAQT/vzRTqbMHwSD5370snG4uJANXfzrleNR2+xVhDPm4/yx6YwTXe2OgcWgx7UxGOplpXacPSaLGbesJB+XT8xhDkIR/vrW80aCEMLs1dJpeUKMd5xRj1++/HW7e6pmr89NtjChuPfNyOfaiua3dFoeUuJYJLaaz0fkExDeO1DY8NX6E/kTRGk8s2wdh6E+fTWPSx+cZkU5h4IvQoAGmfDcslI7ZhbmntKHQ2fuh68GcDWAC9HmX5jRE5OS6h/afqwpeigAoU9cFODwyPdMH4v7FNjo37+1A/cqMNlmg57DZN/99k7UtnqZsl3HeHT2Yx/uxeE6J1e2r5rFPO+pao7+QoyUGXQ6Dld974ZdWPTT4cz87AN59PPSaXnYU+lg2t6zfif2V7dw/c2eOJhpG2fUC9ehbLvy433Iy0rk7P8PbNzF7el9ij0dlhHPob3vm5GPgwq8+QPv7MKdF45h6onw3Cs/3oc4E+tjMOiA+wXobKOB9wlE+ESxZXo963dwenzRexqRsuUzxf6YAGXblpXaUZjL8o5EKPi71+/AHxV+lmWlBdFcG5F6t/39W/5Zrt+J7ceacCqrM98YjlBKN/TYTKT6nURhgOUNPIZaDRu9r7qFQSbXtmjLoKWGzhaZW5RlInOQGtai2uHB366eGPUTVDs8QsS2EiWtNpfqZg+zXrXsdKK2NS3sXBwu8Z42uXzMGI1OD17fcpRDU581KpNru6+6pUM8t2iM6mbxGL8+Lw9rFxZH/RiJFgqdTs+UJcXpcO1zXzPj/umj/XjoUjvWLZ7KcIyCQYrc66xRP0HkAHjxuilMmfKTvCgM9XCdCwOSLQxiWy1cVQ1vciqrMwfD94SQlwG8g5ApCYAMV+1v8vuD2FXRhIomN3KSrMjPsXUZHJZjs3ChqUYDODwyKI/dfnHTQYwbkAC9zoCqZoosmxlmPY+mEGEUOhP6qQy3FJmDUuONwnHTEkwghET9BGnxRiFeWiuuYmCyBb4AbVuvkQ+nFc35nW2hcF9KCXTEB4tBD32ceA+S4oywGPVRnwpoQIi1zk7kMRn+YLBDPLfFGLLVRy6pRfZUjM42wxVuSwG8sfUYzssfwAQhrLpivHBPk60m+AIUviCFP0ARDFLodARGPYFeR2DU66DTERgMOs7RrJRa+HVqvJnzo2l9r5TmqlNNnTkYrAgdCOfHlFGEQHhS/UB+fxBvbytnsAfLZ9oxc9yALh0Ow7PiMLImhbGvl5Xa8buLxjDogmcWTEBqvAJNMbsQ5U1e3P12jI18ZgGHpigrsSMzJs2mxajDOaPSOFSzCLuxfKYdJoOORU7MKeSQ0zpChUhnSoO4bk3b/FbOK9KE+xCVrZhTiB9qWznkxCNzChn0g3DOswtxtMHNoMeFKO4SOwihjG9DhLqIIDaUSJHcZHafi05LEuKqEy06xgeycp4YFX643sna5kvsGJzKIkUyE43cGCvmFGJfdQvjA1kxpxBef7BL765WjLyoXsTHEDtnkbnqVJNEYpxE2vZjA+Y+tYn7RLRu8VSMi8l4pVVqoalKFIIITd0ZBIMSwfyzkenCkNMriwcxCIskix6PfbSPG0OJukgws7Z+tbksmTYC678t58a9b/pYtMSgKdZ+fgA3n5PH4K/T441YtIbHVTyzYBK+OFDf7pzV9koZirv28wP4yYiMDsNu1fb56asnMZhse64NDwvCgh+ZPY5Bj3TqWS4qRnqCOWq+aWj14qH3djMhtmnxRlyn2Cu1MbS+u8cTpu33B5lQV5G56mRUt4SrEkLWAFhKKW0M/5wC4FFK6aJumaXUcUstRK+yyd0l9LBaaKoShSCy4XcGwaBEMI/OThCGMyoRFqpoBY31RP4J0bg1CjQFwOOv1XAVda3eDueitldKNAUQQopraSvaZyUmWy1sVIke6dSzdHhQPDQtar7ZWHGMC7EV7ZXaGFrf3eMJ0zaZ9B2aq041dcaUVBg5FACAUtpACBnf/VOS0iqlPyEnySq0oWYn8fZSl8uHHZUOJt+s2WxgkMRZNrMmVLMI1dAZP0GWjb1jYDGKEdFa/AkWow42s7Z6SkxGQ6tHxSfAh2Aq9yBdBVehDLfsbkREZ1AXafGs38FiEPtAshTokdoWdyeeJY+rUD7LLJtJM45c9O5K9bw6czDoCCEplNIGACCEpHayvVQ3SuRPWLNootBmPDKd/RTlcvnwzs5Krt6QDAsWPLslWvaPX53O2eZFqOaCATZu3LE5NpSV2jm7tBIvXVZiR6uXRXG/deMUoU8gw2bkkN0i+7XHF8RjH7FlonSfSju8CDldVmJnmEyR/hxuH7MHo7LUU2fGth2ekYAHZxbg92+3+RPU0m4mK9JfqqZGVfQXXZvCP+ELBlg899wi7hmVldjR5PIx9drbP+WzVOIq8rNt3LMclh7P+ZpWzC4UrkOm4uwbdQaJsQDAXQBeR8jpfDmABymlL/Tc9DrWqepjEPkT1i6ajHvW7+Rsxo9eVsR8VVbzHTx37WQmQfsrN0zBwrCjM7aeyLZcVjKWSadpNujw2ze2M3NJsujx0uYjHeIq1LDbSt+GyCeg5k9Q+h3UcBAizMPDlxZAT9rwEnodwZUCzPMr10+BN0Cj9usWtwfrtvzIIcqvmDKE8U9kJZpwh2KvNm4vx4MzC1DvZHEQC04fjPREaxQzUtvswqMf7uP2WeR7EWM3JoCCMGiPezfs7nD/Nm4vxw0/HQpbnLldJLYa6lo0lzd+cTr8QSpTcfaSusXHQCldSwjZAuAchG49XxqLx4j9NiHV8xL5E+pbfWKbMYcfVsdaxKqmWdu9A7cviCMNbiad5p/n8ijpm88ZIZwfd49BBbstSkMpGkOL36EzmIcj9S4uTaao7VEFTvvmc0YIEeXKtJuivQKAulYeBzF1uBNLXt3OjKF1D0TPraKJ9ZVo3T8AqGz24u71LCFHlHZT61yONrhwgT1HpuLsB+qUKSh8EKixkj4GMOG4ZySlSSJ/gloaSmVMthoSe1g6m3bTpCfCFJuiGPmBipSTRj3h7jZUNrk0+QSS4sT3DpQ2dz2BZlu1aAxhPQXqOpSy08KguPU6sV0/M5FPPaplDDWctggHofQdiMbojH8nSTEXtTlrvcsxJC2OSdPamdSo0p/Qf9Rt4aqEkG8opb3ujD5VTUkiH8O6xZOxp9LF2eYvsmcg0dr2j67R5cYHO2uYek9eOR41zT6m7JE5hXD7gly8uUdRtqzUDqtJj9/8vc0uvXbRJByqdXNzSYozYOmr37bb30vXT8YP1fw6Bqebcc3qtrsSK+cWocntZ2zkov5EZU9eNR41Dh/vx0g04saXvmHWZjHqmLsIK+cVocnp59qmxBvxq1fab1tWakeSld0DtbnkJptw/dqvmf7MRvYOhGiMFbML4Q2wdwJEe6/Wn5YxQj4QI5a88k27+7JidiF8Acr4DpaV2mGzGLg0niUFObBYpNuyt9SeKak7D4avKaW9/o3hVD0YgLaopIhN1uMPCuP/H5kzjrH7bj5Yx9WbOjQVN7zQcWy51ph2Nf+EMpZe5BNQaytKG6nFnyCqp3ZnQYT21nrfQdT2hUXFqHB4GGT38ne/5+by+f4aJtZ/7ecHMG1MNoOhVvMdLJ2Wx+GqlXc+Nm4vx90Xj4XLH+wQ2S26P3H+2Gyuv0fnjIM3SKP+DqOOCNO5Pj5vPLYdbepwr7p630aqa5KpPU9SGQw6jDstJWqTfWfbMSHmucnlw7YfG6JhrVUOD2eXzsvUFlsepMDIzARcf9bwqCnp6U9+4JDYalykeqeXmZ8vQDn0c12LV9hWlDZSNBfRPQblGAadTpO/Q2QPV7vvIGrbqEB2BwJ+nD40Fdf+dCiDAC9v9DDIifJGD0x6HUZlx7WF0zo9Qky2L8A/c5FPoN7p1eRPULs/oeyvwuFBWoIJlIacjpUqvislEkNtr7p630aq+9WdB8Opme2iH2lAskWIeXb7gtEIJotRh9XXTtbknxDZqrMTTRw6+4GSfJgMOvz5ox0xY/DYY4tRh7QEE559oy3M869Xjufm/MwCcVulryQvw4oByexc7puRD6virbaZ9dwYf5pb1GVbulYb/uA0KxxuP2NeWj6zADMnDOAQ4HddNBJ3vNFmgvndRaMRbzFy+3zLuSOiUUORbwsjsxJw08vfMGV6IVeK99GI7f/aUmxm28zRbwgh86EKkl1rf9LH0G/UmdSeXFiqomxat8xIqstSmkzcPjGa+rEPvudSIQZokEu3GImvjy0blpnIobPv27ALB2tbFWPsEaZb/POHe5h6eypbuDk7vQEh/loX/kUWKctJjufm8sA7u5CbHM/UG5Vj48Z4+L3vuFScZSX5HPp5WakdmYlmpmxIejweUKCuHyjJx9B0dtw7LxwT5R9Fxr377R34oYbdq3s37EJynJkpq231cm3v27ALcSYjU7by433YW8VjvEfn2Li9VyKxh2cmCJHdOh24svR4E/c83L4AM25ds4vbl0j/sWWPXlaEPMU+yzsL/Uud+caQH/sDIUQPYGLkZ0ppfXdNSqprqlPBSyu/tm853ISbzzEyeGS9PoDyOg9T5gsG8MaWo1h97eSoHblexcwjGuPKKRTPLyxGTbMbGYkWOL0+bDnMcu5FiO2GVq8Qf52bbGXK1EIhq5rdTL0mJ78vh+tcaHL6OJT0reePxJqFxdG7CE6fD797cy837rvbK7i2FxfmMPX2xXD+29urkLnFx5SpISKUIbuhsgBX1uzxK55vEC998SPzLI/WO/HipsMdrqPJ5cWaz/nn8etz85hxd1W2YtfRRgYf/vxnBzF/ymAGfz0kLR7BIMWg1Dh5Z6GfqsODgRByF4DfAbASQhyRYgBeAE/14NykOik1/LDoa7tBp4OfUlAKBChFVaMH28sdGJaVHC1Lspqw9cdG5KTEh2zaVS04Y0SaJnS2xaiD0xuExx9AIAh4/QHoCY/dFoWXxlsMQlRzWnxbZjFCgGyV9aYnmAG0ROulxIvDQZvcPiz7x3dMWYrVhMMNLrg8AVTDg0SLnsOM6wDsrW7BEkXe5rMVqSnVsNZaMpUdr5nHZjZGwYR7qlpQODAJ7+6qwpvftmWYWzpthOZ1iJ6HMuw2waTHFwfr8e+9tUy9X/58BJrdPjQ6fbAaDQgGKecfk+pf6vBgoJQ+BOAhQshDlNK7emFOUl2UGCs8DoEgjf6SiYQVHmvycLiKn+Yp01Xacf+MsUz45iUFGUJcRayPItKfSa9jbOkPzuKx2ytmF+LBWQUMctqoJ0L8dYPTy2AoxmQnqmAoOkZ2RExkzL7MLcKe6hYu/FWJtRahM9RwFUoEuBpKQoTOULYtK7XDqCdMPdE6ykrscPr8zB6IMN4ibElZqR1JMak325uLTgdmDBHyvKzEjnqnlwmTPR4UvFTvqFPhqoSQAQAGI+ZAoZR+0gPz0qxTOVxVJCVW2On14/4NO5lQyJwYp2FEFqMaMmEiFqz+Klr22uKpWPAc3/aFRcX4v71t6Gw15IRojJeum4IWrz9qfrCZDXjyP/sYlERFgxP3b/yO6++JeUVIspqiJpMEix6XPvkFV0+J7Hhp00GUjBuA9ERr1NTl9vnxixe/ZtqqhedqDRG98axhyEmJY8Y9f2w2MmzsXK4/cxiCVBedy0e7yjF5WBqSrJZoWW2zCxu2lXOIjbPyMhk0hSgk1mLU4emrJ8Jo0Ef7q2x04k8f7+PCbu84fxTSEy3Rd2jT/ioMTk9AZlJc1AwFGsSiNVu5MdYtngqvPxi94JZg0WPWX/nnIUNT+17dhd1+GMA8hG4+R4yaFIDqwUAIWY1QbuhqSqk9XFYE4H8BWAD4AfySUro5/Hd3Abgu3P8SSuk/tc5PKiQlVvj9nRUc9lgN6aDF9l3VrIL2drg1ISdEYxxrYlEST8wv4lASaqGV28odWPWvtnHV8NdKZAcAjMxOxqpXtrU7Z3VbPx8OKgoRPdrkwZ1v7eLG/c3r7FyUmAwAsJjNWPWvb6M/qyE2RmYnM2gKtb061uTmwlVFYbffVbVgVczziNT99WttbdWe74/1Lkwflxste39nhfh9kaGp/VqdcT7PAjCKUurpsGabngewCsDamLIVAB6glL5HCLk4/PPZhJCxCB08+QByAXxECBlJKQ1ASrNaXR7sqmyJfmIbnW3FLecMxdQRWagOoy70pM0cEZGarTpVgZdW82NkJbKhhvEx5oiOxhiUEscgJ+LNerx54yT4A4YonkNHgnjmU76/MVkJWLd4anRtABX6QEQYjzOHp+CsEW0IkEAwqBmxIUI6CNN9KlAhL246iMwEfi5KjLdozg2tHuHaRPhwUb0smxkv3zAFtc0eZCSacazRqdlfpCxTe76npVoZJMawdO0oeJG6M1WtlHZ15mA4AMCImHzPHYlS+gkhZIiyGIAt/OckAMfCfy4F8Gr44DlICNkPoBjAF52Y4ymtVpcH/9hZzdjSV84rQk5KIq6JSc/5SCcwykpb9SUFmSrpIFnbd7JVz9WLpLXsyK7/0KUF0BOCO95ow0GsmF2IR2YX4vYYG/kfZxciQMGs7cmrxnM+kAg6g0l1WWpHoyuApevafCBPXsm3XTGbt5uLsBEiP0sEKcLeWeDx4SKUuQgLvnymXZgadXimBVc+04ZLXzGnEDf/PI/zvVAo0oKq1BuUasZTn7B+jOQ4dm2JZv75PjKnEHurWrj+nrxqPLNeraGp3Z2qVkq7OvQxEEKeQOiX+QAA4xCC5UUPB0rpkg7aDwGwMcaUNAbAPxGKbNIB+Aml9DAhZBWATZTSF8P1ngXwHqX09fb6lz6GNolw2moI699dNBrJ8W12aZtFj5e/PMTYr0UI5rWLJuPxj/dy+Ial00ZpShu5rDSfwTwbdIRL86jmi3j5uin4eE9NtL9pozJwhQJ/LVpvZzDeIn+CErGhhqZYs7AYVc2edlNYivw2auvVWrZmYTHmakjFqXW9axcV4z8x/qKN28vxlysmIM5kYEJOvd4AdlQ0Rb8dABD6rtYuKobZoOt0aGp3p6qVYnW8PobIb92tADZ0w3xuBHALpfQNQsjlAJ4FcC7EN6eFpxYhZDGAxQAwaNCgbphS9yviBI5kQ1PLQdudqnJ4OESExx8U2nirW7y4d0ObXfqPlxagssmLJpcfbm8ADkLgFrStb/UJ8Q2tXj9GZSdGx/UFgxiWFo/ioSlRM8ru8kY0uvwASHSMIKWafRHlTW5mjHIBerzV4+ewEYGgeA9EGG9RPa2pQqub3VgSY5tX83co/TZq61ViRt7YelRYr1pjKk6t661S+IsAoDyMxFamxExLMMMfpEhLMGN3hUOlPw9mjMvttE+hu1PVSmmXlnDVNd085jUAlob//HcAz4T/fBRA7OMeiDYzk3JOTyF8h2LSpEndQwHsRgWDFO/vqmTCRh+7vAgX5mf36OEwJM3K4Sqeunqiqo08VllJZiHqYtLgJOZSWm6KWYjdCAQp0/aJ+eNxUUEOh36wGvUMIuL5hTyeQ80XkWUzR78RWYxitEdKgomb37JSOwanWXG4zqXYA22ICK1IjND9iTapIadFOG0RTiPRYsSfP2pbhxrqIlPh39F6B0KtnhI9IvIJiN7x/71K/K5lK9J9alVnUtVKda86g8TYQQjZrvjvU0LInwghaR33ENUxAD8L//kcAPvCf94AYB4hxEwIGQogD8DmTvTbb3SorjX6DwYIfcq59bVvcaiutUfHdfuCHCLi+wqHEC8xMotFEhj1OiHqYum0UUw9UCLEbuypYrEbHl8I9RBbdu+GXfD4gkzZ3spmbn6/u2g0RmSw8ysryUdqnJ4dV4D2sBp5LMg963fivhksqmFZqR0GPYt+GJYRj4dmFXD1lPiG4QJUSFlJPoI0yJT5gzxmpKzEjoCingi7cddFY7Bs425mHSs/3odRStRFiR0gAXZ+GfEC3Ae/3iHponr5sFn0TJnIJyB6x+/bsJPrL4LT6Iryc2xcfxKd0TvqjPP5PYTCSF8O/zwPIfNPE0LRRzOUDQghrwA4G0A6IeQogPsA3ABgJSHEAMCNsEmIUrqLEPIaQuGwfgA3nagRSWqohupmN/NVvLslols6PAG8sfUohzOYXzyIKStvVA9Dja2n9vW+q1nYqlu83Pye/M8B/GluAYN08Aa8eHtbFdN2y+EmLDgdDMJCjerq9QeZ/lw+P57/7yEO3zCveBBXds0ZQxi0R5PLjW8ONTBl/9xRDqspjcFL/PnDfbjpnGFcvfTETGaMYw1O/OXfPzB7EMs/il1Hi5tFXSTF6fDwu3u5Od9w1lCmnkEfxP0bvufwF1edPpjBZLz+1RGkxJmwbvHUdn0CondcDTMyND0OQzMT0VkZDDrMHDcAeZkJEp3Ry+rMwXAGpfSMmJ93EEL+Syk9gxBylagBpXS+Sl8TRYWU0gcBPNiJOfVLZdks4pBJmwUHaloYvwMAzhchKos4+iodHmTbzCjISYLJpGfqZdvM3Lg2sx4Dks2MbX5AshkJZj2GpMdHyywGnXDOA1MsGJQaFw0HDVJxOKgyZNISE30UkcXIZwxLMOmFuIUfqp0YmBqHQBBw+wN4cdMR/HREJhfmeVqKBb7wxwcSzugmGjctwYRAuIgCSI03ISPRCKNeBwLApNchI9GIeLMB9U5f1AfS7PHBoNOhutkDlyeAGnjQ5PTilS3leO6LH5kxTh+RGc07AABNbh8O17rQ5G6Join+tbcW59tz4A3QKK46SIGCAQmMP6ai0ali1iIc6qLZ42N8Q80eH4x6fdthTYAg1QnxF0cbXLjj9R1M2TVnDO0QV6EWtizCjChNXZ2RRGeIpQxLz89OQLy1ayY7kTTffCaEbAOwmFL6ZfjnYgBPU0rH9VX2NqB/RiWJwuwemVMIHdHhtr+zfgeTgeDmGGSyqGztdZNwqMbNhVHqdQS3xWRNe/0XU7D7WCsXrirKNqbMDvbWjVOwo7yVG0OZCUw185kiBFOUXU0U5rlidiGClOLON9uQGH+8tBCEgENn+IKUQWc8NKsAeh3hwjeVmdREmegenFUAo6BtwYB4zHryy3b3Si0Tndcf5MJaLcaOM7itWTgRh+s8HLJDmRUvFJpqxZXPfNXh8+VCWAX7pxZ2e4k9s8NfMiIfw6OXFSFAg2x/pXbMLMyFSeHTkuq6RGHpWp9brLolgxshZDKA1QASEPqg4wBwPYBdAC6hlL6meUbdqP54MByoacHFj3/KfJrSmvlMVCbKaCbqb93iqdGY/ojUQjW1oC5EY2gN/Qw5IyfA4Q5EzQoJJh1++TKPydAShtqZ/Vu7qBiVjo7DRoVtFxbj8pjQT7W1rVk4GW5/MGq+MekJFj6vbQyt2e7WLJyMT/bVMWGjD19aiPlPf9nh83ju2slMPYtRh5evn4JgmA6bZbPArCe4+dVvOsz4pyYRfuWml7/m+nt83ngZXtqNEoWlR957Lc8tom5BYlBKvwJQQAhJQuhAaYz56z45FPqrRPZXtdBALRnDapp5u7mov2oBrkLN1q8FdSEaQ6vvwO0LhSnGIhjUMArlTSyWYXR2wnHtX5VDW9iosK0i9FNtbdXNHgbj0ZkxtDzfyBjKsNHaFvZ+qdrzUNZz+4Iob3RjRgyu4p1tx4RIjCqHtjusIvyKqD8ZXtq9qlLJlKf1uWmRFuz2VZTSFwkhtyrKAQCU0se6bTYniUT2V62hkBajDjYzG7+ekyzuT2nrF/k2UhLEyGktqAvRnNVQCKlxPOZB6U9IijNi0uCk0OW4mHpZNgvTNttm5urVtrg171+WzcKgH4jK3iv3+Z1t5chKtHBlItS11tBULXiJjETeN/TOtnJuDIsxFKoZOz+155uVyO7BW18fiV5CiyjLZha37ebw0kFpVia1rMRaHJ+6+7mJpOUbQ3z4/50PKzhFJcJfFwxM4soi/oTIQ7YYdVh1xXg0On147KM2++Hw9HghMnlgShxjNy8ekswhHZbP5BHRItTFWXmpHOJAhFtWQ2K7/AFuDLOJMGM8edV4XD6JvSsRQjUEmLI1iyZy9VbMLsQfZhXgdwIfQ+z+lZXYodcFsWA1i4hQruP/XTYOLm+A2eeyEjv0+iAz57ISO5Lj9dwYARpgygLh0FTlvsSZ2LYi9IjJQIUo8zgTmHorZhfix3oXj9NWPt8wonzpum+Z/kZmxzPvaUE2jyMvK7GjINum8ma3r0h4aew+r5xXhJ3lzRx+RWItuq787AThc8vP7r6Ix05ht/uj+qOPAeDtr7HRRu2VUQpc8gTrnwj9khmLASnx0bDC8oZW3LOexVWo2ZtfvK4Y3gCNto036jH3aRY1sGTaCKz/tpyzD/9l/ng4vcFo2KNRTzgktsWowzWreRu50jav1d+xdtFkLH6BRzo/d+0kfLa/npnfk1eOR4u7bX4p8XrMWMVjnp+8cgJ0ujYUx9F6J5b9g8d4qyEnArRt/97++ggusOei1RtksCDzJp/G4bTnTh7M1bu/xA6nJxCdMwiENuM1C4tBgGi9hlYPlr7G799L101BIEij9cxGnRAlIbJBu1w+7Kh0RKNbCrJtsFrZC3idUQR6FwkvpRSY97TEWnS3uiMqqbuw2yMBPAkgi1JqJ4QUAiihlC7v1GxOESntrxF1VPbFD7VC++Hhejduj0E1i7AMavbmiiY3Yw9/fB5vDw9SCO3DP9Q6sfTVtrYiJLaafV1pm9fq76hXSVFa3ezl5rejvJnxY4jWFrHXK5HTWn0C1c3s/gHAxCHpHCZ76vAMTTjtg7WtHT4P0bjqOG0eW67VBm21GjvlsOxIyvBSid3uGcVbzSge2n2mI6U6c4/haQC3A/gbAFBKtxNCXgYgD4bjkNcbwPZjTah0uJFjsyA9QWw/VGKe1VJiitpm2ywM1tqkJ5wNv6HVI2w7MNmC1xa3oamNOr5tapzYvq60zbfnn4hdW5qK3VyEksiymRn/xMAUcXx9V/EXEX+CFr+DuC3ve1HG9Wckip95RiKL7P6xXny3QemjyewFG7RWSazFianOHAxxlNLNEadzWH61ylIdy+sN4O3tx7hUko9eVsTcdxDFh69ZNJGzM5oNOqGdu8LhZto+MqcQcyezNvxlpXY8MqeQibl/ZE4hDtQ6Gfvwo5eN49qunFfEp4gsscOo8J9Yjfz8RP6OM/NShPWSLDyyu7rZy6WmXDm3iLWvl/JzKTotSTxGHJvWsqzEDq8CiV1WYke8mZ2LCCm+Yk4hGpw+LtVlchxbL84I4VxcPj9zN0SUBrWsxI5Wr495Hk9eNV7Ynz27992EIr+DxFr0f3XmHsN7AG4G8HdK6QRCyBwA11FKL+rJCXak/upj0KIth+pxlSJe32LU4dUbpsJmNUb9DjoCXLiS9Tu8csMU3PnmdsYncPaodPzxve8YJLbo7oDanYC/XDEeBr2uXSS2WtvXFk9FizcQtcPbzAbc9Aob037OqAys++oQZk4Y1G6KyLWLJuOe9Ts5f8fDlxaipsUbXZtZr8PSdfy9iGcXTIJRr2vDaQR9+L/vqnFu/gAmjed9G3ZxYzw0qwC+II3uQY3DhbsVvhyLUYc7Lgilv4z1Hdx2/kgQ0pY6E6C49jnR/YRifLKvDWs9dWgq3tn2I7Mvtc0u3PHGTqE/obzJzYz7kxEZnF9k/U2no8kViNqg7dmJiLN2jVl0vFL6HSTWon+oW3wMAG5CiGg6mhBSDuAggCu7YX6njJTZqET3Dty+IMobXbBZjYic2RVNblycn4U5kwdFww+bPX4kWYwM6qKyyY1BKXFITzChtpkiI8GEJpdX6E8QjevzUySa9XAQH6zGEKpCibCOM+mFbQ/Xu5CVGDJVGHQEda0enDMyHWfmpUdNWC6/D/EmA3ThzvSEoNEV4MZo9QSE/o7aFg9zP0HtXkRtqwd7q1qj2IgEsx7P/PdHPPPfH5m2Xn/bhyJCAK+foq7Vi+8rW9pMdmbxehMseiRZDQgGKZKtBiSajTja4MGhOmd03LxM/j6G2xeEw+1j8Be+YACvba3Aa1srovXa8yfsiZlfeaNH6Bc5WOtCekIoVFdPCAx68c3j3sDDS6zFiafOHAzlAJ4D8G8AqQjdfL4GQFkPzOukkwiT8b9XijHFKXGm6M1pi1GH1/5nKqYOT2eyb/1hVgEW/nQoY0JYf9PpcHnZestnFnDIaZF9fXCaFU5fAL+OyYb20KUFuPFnw/CH976Plt07fawQYa1EYj951XiMyU3BtTH9rZhTiLED2LJH5ozDwjOG4LEP9zJrE4/RcfrQwWlW+AKUMf3cPyOf629gioXDcy+dloeUeBPTVrTe88emA1THIMUfKMnHyKx4xuy2dlGxcH4Olx+/fzvGHFRq5/Dmaj6QjEQzY+5TQ3HbrMbot9HIGEo0RV/h4aX6vzrzfW49QgRVH0Lo7BYAPcuRPom0q6IpeigAYUzxOzuxfCaLeS4rteOxD79n6rV6AhzC+ndv7cDB2lamrMnF17v77R24X4F+HpGZgAdKWAz1vdPzo3cEIm3venMHalu9TFnZxt0cwvq+Gfkw6wlTT090URt3pGx/dVvax0jZvurm6KEQu7Y7LxzDjLF0Wl40/j9SBlBuLvdOz+f2+f53dnH9mQw8nnvlx/uw42gTt957p7NjLDxjOLe2+zbsgtPLIsVdXj+HFL9nen70UIjUu3f9TtxyHos3V0N7r/7sB27OI7Nt3PM4UN3MjbH9WNvBA/QdHl6q/6sz3xgGUkov7LGZnOQS4aoP17mQnmDEi9dNiX6V1+vAfHIE1JEJShOCGu671eNnkM7BIMVLmw4zeOR9KphnkZlChFa+4axhTD1RyKnIhKVm1tpX3cKhwgemxDFlRxtceHd7haZ1KPurVNsrb4Ara3B6mbbVKs9DiaGobPJg7ReHmbaNTt60FxrDx2Cygwjgb/93kMFpVzlcTJhwpO33lc3c8zhrVCZXr8rB4j76Cg8v1f/VmYPhc0JIAaV0R8dVpZRSC9tLiTMxF30O1LRw4aAZiSYhMkEZwqqGQs5IMCECQiYEsJoNHIJ56bQRmsM3jXodB5VThnSKQk5F5hE1k4k/GORQ3AOSLaBAdF+anB7N61D2t27xVM3rTYgJTSUESIsXh9Mq9yApzsghxVddMV7YNjPBzMD71i6ajC8O1uPfe9sOArW1Ob1+Dqc9vTCHx30oTHFq78vxYLKlTg51aEqKZG4D8FMAXxNC9oSzt0XKpTRIazaq3ERLFAfx2zd34PbXt8EfDOCms/Pw7GcHsOpf+/HMpwdw08/zMCw9nilLi9dzGcOWldpR0+Jl6jlcPqyYXdih6eLhSwsEmdTsSI7Tc2VxJjBjEPDZyyYPTebKhmck4EFF1rQ/zOLHXTG7EEfqncy+mAwGrJxXxPWnzMK2fKad68+g5+e3rNSO0VmJXJk3GGTW1uD0Csw8drj9fsUegMswZ9QRYdu0BHZPA5SfXwRRomybn8uaklbMKURKvJl9X87Og12BuoigW2LbPnZ5UfRGvtSpqw7DVQkhg9v7e0rp4W6dUSd1IoWragnbE4WwakVOi0JYkyx6PPbRPq7t0ml5aPEEmHovbT7Chb/+5u/buJDOOy8cg53HHO3ioJdMG4HvKxoZdIbVoMftb/D9PXxpAYO6SLLosb/awYRvihAgFqMOz14zCYQQBldxSeEAgBAGTXHdmcMQCBKmvz0VTUwI60e7yjF93Gnw+IPRUGGjDrjiWR5Xse6GqXDH1DPoKK58lg9Nvfvi0bDFmZnw0ssnnYasJBadcf2ZIwCKmIxrfuQmxeNIgycachpv1uOXL/FY68cuK0KQ0mi9ZKsJM/7yGTeXd5ecyZmIROgW6Xg+NXRc4ap9/Yv/ZJKWsD2R7Vsrcrqm2cOFeaqFPbZ6A1w9ZdtRWQnCsFGH29chDjpIwaEznphfJOxPibq4+ZwRmsM3a1u8DLIDEOMqlGiKm88ZwYWwAsC4QWmacNpHGpxMPbXQ2cpmL+5ev5spnzo8A3e8waIzZowbyGE3Xl08BVOHpUd/3rhdjMmudLhxSWEbTlsNqyLyHaihW6RObXXGxyB1nNISM56jgr8W+RhE+GatqAtlWz0JhWFeOXVoNL7epJLuM0OAeVAiovUEuHxiDmZOaLt7EUtCjZ2LEnXRGV9EWryJs6UPSbMyCJAPd5UjRYHdECFFLMZQSGwshsKgI8I9yErsOHRWzWchRIUnsuiR7UdqOVu/6N2wGHUYmMxirTNVsCoi34Hybs3xIrF7416EVM9LHgy9JK0x43lZcRzOYNb4LAxIjuMQB4PTzXjqkza0QmaigcNVi1AXZaV2JFlY9MPkockYkBzHxOa//otiDge9YnYh6jVgHn4yPAWH6+KYOxUr5xUJUQ0BGmTajgj7O2LvBKghLHxBFlfxyJxCHKl3M23LSuwwGVgE+Io5hdwYEWR37B48s2CCEImdaGURG0Yd4bAgEV9CbL1IOs3YsgjuOzYVZ1mJHRkJ7D/PMVk8bnnF7ELsr2ll7kU8IsCqiHwHors1x4PElvciTh5J7HYvSZTuU2T33XywDre/ztrhf5aXzqXdtBhDaSj/E4NWUKv358uLsEPhE5g3eRDjY5g6NBU3vMDiL7SmFBXN5acj0oTpKp++egKCYO3/kwanocnN+ju2HK5j/BM+fxDL/rGbs6/ffv5oJkJKbX5KtLfFqMOt5+Yx44r6U0OFP79wMjwxqT1f2nQQN/18JFpjsCC1zS6s/eIwgyhZ+/kBXDVlEDKT4hi/SHZyvDBFaSz5dMuhejz83m6mvzhjKEJMOb/Xf3E64kyGdn0H235sEOK5u4rE1vqOS/UPdRcSQ+o4pDVmvMrB+wlEqS7dvlAOAi31mgQ+AaWPIS+Tt6VrTSkqmsuoLPFcjjV5OPv/yOxkzseg9E/88dICoX1difZWm58S7e32BeHwBDrsTw0VXqNI7QnwfoKbzxmBLYebsOXwN0y9qcNd+PVr7B7cfM4IbgwlJrvS4eb6U02X2uDCBfacdn8hi+7WuH1dR2LLexEnj+TB0EvKslk4G/6Lmw4iJ8nC2IcHJvPpOdXizbMFKTFF9USIaOUdiLQEE+cTiM0uF5Gav0Npc1dDSdsU6T7f2VbOpdi0mfXcXvn8QU1rU/NFZCbyvghRak+tqHBR2s0BSVbmeTQ5PcJUppkCH40wzajNjAM1LVF7fW4S/x6ootY1YK07g8TW4juQ9yJOHsmDoZeUm2jBuWNyGfv1slI7dpQ78Ju/t/kE/jCrALedN4pJ4zlnQpYQp13T7GH8CX+9QoxbNils2g/OKoBRR5gxLsxPx6QhGQrOkl2YUnRAShyH2E5RpL80GahwLhYja+uP2OEfi/GBPHnVeCTHmZm9Wjm3iPcJlNph1LO2/uGZfDrSFbMLUd7o7nDcshI7MhJZ30vk3oHSFxFU+EVWzC7EgbpWzl6/4PShXCrTpDgDlr76bYdzMRvAMLOemD+em4tRz89PK9ZaKxJbq+9AlNJW3os4MSV9DL0kNcS2KJWksmzV/PHYsO1HxuZe0eDE/Rv51JSiuPkbzx7BpJeMN+lwkwLFvW7xVFwj8E+smj8eTl9b29pmN1b8cw9X77lrJ+Oz/XWMz+Lu9Ts4n0Bp0YAO16uW2nPdDVNxuMEVnYvNoheis1fOLYLX35bqMhAMYqECH662908vmIQGp4/Zv3um58Pja0sfmp2sx9r/HmHuQHj9AeGcRWMoU56q1RP5Rd791U9R7/RFP7kX5iZBpyNdxlpruVvTGd+BvBdx4kj6GHpYWr5mq7F5RCwiZVmrx48d5S3YfLCBwUErcdVvbD2KFm8AFY5mBstc2+Jl7Pp/vLSAa6uGAG90+XCw1hmtZ9LrhPVqWzycz0LkE9CyXrXUnkcanAxyekhanHCMHxtcmu4YiOZS38rfizhS78L3lc1RnPaQtDjUt/oRpBSUApRSNKjMWTSG0o+hVk/kF6lq9iDLZoEvEERqvAkGgw46Heky1lrL3ZrO+A7kvYiTQ/JgOE5p/ZqtFoOuJc49JcHEIaLLSvI5JPat541ERqIZf/6oLXRx6bQ8pMSxCVoGCJDTIkS0xahDcpwJz37WZmr409wiTTb31Hhxuk8t61Vrm2WzMGG3f7ligqa5JKmkHhXNJVWxV6Fxzbg9xhz0yg3FCAZZvPmTV4rnIhpDa1pQ0Vx8AcqYl3ojHFT6Dk49yTRKxymt6OIMm4lDXS8rtWOUgs2zfKYdmWHHbaTMbNBxiOh7N+zikNiPfbiXQ3Gv/HgfLEadoj8eOU0RRJlifstnFmDZRhbj/fB73+FBBSr8gZJ86HWUKWt0egT98cyiZaV2jFTsQZBSbq8eKMlHXbOLmUvZxl3cXMpK7AgEA0xZstXA4bkfKMnHiMwErsxqIor+8pESp2fGdfsohze//51duGf6WKbt7ReM4sZYFpNmNLZMNJcEC8tP+uPsQtyzfkeH71p3SzKVTj316DcGQshqANMBVFNK7eGydQBGhaskA2iklBaF/+4uANcBCABYQin9Z0/Orzuk9Wt2eYMb7++oYDDKz392EL88ZwTWLZ4atfEGKcUvX/qGQTVv+7FJOIYWs4zbF8TuChbLXCGY86EaF748UIvV106Oxtcfrm1hEtQAIVR4q9fPrWP84FRmzg+9txe3nDeCw0Z/c7gBzy8sjtrm/7mjHGeNzmTKjtS14P0dldwY+QOTubkkxRkYXPW3R2rh9vuZ9X77owPv7jjGoannF5/GjXHV6YOZ/vZWNmD9tipmXFEY7+E6F5rdPmYPnvn0IB661M483/ycJASDlEOtP/7RPm4ug1KH490lZ0bt9XWtHu559EY4qE5HcGF+NkbHzEX6Dk5u9bQp6XkAqwCsjRRQSudG/kwIeRRAU/jPYwHMA5APIBfAR4SQkZRSFpDfz6T2NVsZhpqbbMGBulbGT3CgrhUpVhNavX6Efp8TJFuNuP28YRiYaoviEZwen2YzRUFOIodWGJoRh0SLCVXNFFk2Mww6woWD6nXAX//TiJyU+ND8qlpUsRGm8PdMSgECwGgAkq0GJMeboyGYA5LNaGz14XCdmwlDLW9yweMPIBAEvP4AyptcSLGa4PQFo/Z6vY7AaODHyE7kwzyTLEY4faH+3P4AthxpxKTBadgT42dJMOk5PLfFqEOjy4+jjezzSDAbUdnsgcsTQBU8eHtbJeYXD8LLN0xpC+PVi9EeTsXdkNC3FRN8AQpfkMIfoAgGKUwmPSYNSY3WO1DTInw3smwWzl4vChXuDZOO9B2cWurxqCRCyBAAGyPfGGLKCYAjAM6hlO4Lf1sApfSh8N//E8D9lNIv2uu/r6OSRD6Gv109ATXNXi4M0GzQMTbyZaV22Kxs6OJbv5yCHUdbWezBnEJ4fEEuJNGk1zGhpA9fWgAdYcNQQ6GkRvwqfDvWYhSHq0ZCJmPn98yCCTjW6OUQDN5AkENiKMcQ1RONK6r3yJxCuBXrjaAk7lCEdOYmm3D92q/bDQcV7V8EC7J03bdsfykmXL/ma2Z+viDF79/a0e7ei+a3Yk4hvL4g7laMq0yxqRVN0d0IC6lTW+1FJfXlwXAWgMciEyOErAKwiVL6YvjnZwG8Ryl9vb3++/pgAPgQvWaXD3Of5lEDWkJTX1s8VYi1EOEbVs4tgtMXjJp+LAYdrniGD4nVGh4pChu9Z/1OJhw0wcz6J9TG0IoKF9XT2lZtbaIy0f6JQmeVIaJqc3npuinwBGL3nuCW11iUSUGuDb+O8T9F2r543RTuG4OWcFCJnJDqTvXXcNX5AF6J+VlksBSeWoSQxQAWA8CgQYO6f2adlPJr9vs7K7rsE6hSCRsV4RsO17uY0Mon5osR0VrDI0Vho9ox3trQFMoxOpPuU2vop6hMtH9aQkTV5nKsycXhuZV7pRYm29UUmxI5IdVb6pODgRBiAHApgIkxxUcBxEZTDwRwTNSeUvoUgKeA0DeGHpqmUJrQ2SqoARH2YFAKi3mOU7Hri9oOSGbbWozitlrDI7WEjaohJ0RoCi2o8M4gtrWGfioR26Jx1frTggC3GHUcAkS0V2q4iiybhUFdZCaqpWRl6+UIkBgWowwblep+9ZVh8lwA31NKj8aUbQAwjxBiJoQMBZAHYHOfzE5FEX/CxY9/ivlPf4mLH/8U7++qRFDx0XNURgKXlnHFnEKkJrDpFn9z/igQosP/vLAVv173LRa/sBXHmtxc6kdRqsZfnZOHY01upm2ciXDjRn7WEjaapwiZDAQF6SUFKUDLStpQ0pGysbk23PRzPh1pfg6bhlKUrnJsrk2YdlM5v1gkRnSvZhfC4fZxaS2V6S9FexAKdQ1y81OmHi0rsSPRwo6r01FuzsI0nqV2eAN+5h06WNciDAc9WNfC1Ntd0RzNGR1bT4aNSnW3etTHQAh5BcDZANIBVAG4j1L6LCHkeYT8Cf+rqP97AIsA+AH8mlL6Xkdj9KaPQauNd9uPDVi2cReDRxahJNTt18UIBNvSPOr1BFcKfAcie72eBjB1RFbU37FpfxV+NjqbQUTo9QG0uH2wGi3RMouJ4FevfMvhJW47Lw/piVYGJb39xwYuJeaZI7OYdJqBAMUvX/6am/M9l4zBwNQ4Ba46Dy4fjfbn8ftx73oedfGny4vgDbTVa2hx4a1vyxlUSDBIceNL/LgvXT8FgUDbHgxM1aO+1QenRxctS4rT4dEP9jL9hdJuDgNoW71EK/CLF7dxvpdvjtRxbW89bxRaPMG2bwc2E87/E/8Ovb/0TAQpos9NR4ALV/L1/vGrM0EIZNio1HGrz3wMlNL5KuXXqpQ/CODBnpzT8Uirjbeiiccji2zzavbro41uTb4Dkb3+8X8dBP51kCkfkpnE9HfzOSOw6l+svV0Na7232oklr25n2opSYuZlJ3PYDdGcKxwe/P7tXUz5JYUDmfmpzaW80cVhrUV4btG4+6tbuNSeyj0Q9QeEsOCxdUVpUNXazp4wCBfYc6I/q6XdrHS4MXVYevQ9UqtX08LWk5LqCZ2SSAxROkOfL4AdlY5oQvWCbBusVtberBUNkJNk5ezrCSY9h2BucorTbg5IZtM8GlXi5pXobJtZLV2lmYnDr21x4Q+lozAiKyU6BgjVZNdXx1qbGX+HP6Ctv1Bb1ieghrDISDQz9xhEaUvV7PrK+VU7+D3wBvx45lO+7dA0K7N/Nc0uoV9E5FNRIqy1vkPtoda3HKpHpcONHJsFBbkh6J1MpynVnTrl6KqiWPAnrxqPGoePQ0TPsGczh4NWLpLT5cXGnVVMf89cMwHHGrzcGMqYe1GMvNZ7DKJY+uUz7TAZ2DLRekX9lZXYkWEz4sYX2+4nrJxXhCann12H4E7AijmF8PqDXMw9t7bZhQgEKe56i01NqbzHIJqL6O7FyrlFcLj9TFvRXP4wqwAGHX/nY0CKGdet2drhXDJtJvzixa/ZfXH5WRy54M6C1ndI7X5MlcPLjTEwxYxFz29ttz8pKaX69B5DT6uzB4MonaEa5lmZWhHQhhX+6mAdrl69WdMYf7q8CDtj0m6OG5iEJa/yqRqVcfhJFj0e+4i/T7B0Wh6TslPUn9pclG03bi/HgzMLUB+Doa5tdmPNF4c04bT/csV4DvddtnG3pnsRv7todOgmdQz++icjMrgxXrpuCgLBNt/B/qoG5A9IY/Dc6fFGLNKI3V67qBj/2duWovT0Yam4fi3fVpnKVG0dx4OmVtZraPXiSgG6XYjnlncbpDpQf73H0CcSpTNUwzwrUysCoX+szW4fGp0+WI0GBIMUfn8Q2481Rb/e17TwLB21MRyKtJtqNnK3v+0AJwRw+6mwXrbNhJzkeNSEf5n4gn4Osd3oFM9Fme4TAOpavdhb1Ya6Nul1SLIYMSo7MWrS+XRvKMw21hz0xtajQty31nsR1S1e3LthN1M+dXgGV6+iyY3vYpDYb2w9ivtLwr8QwzgNtb0X3WOocrg7THka8iu1vRuEAL6A+HkcD5paWW9jxTHhGCI8t7zbIHU8OuUOBtEdA3XMM4tvFpmhRKYGEYJZbQytqSTzMhNwS4xZYdX88Vy9SYOT4AsSXBu+OR0xe9xxQR7uemtXu/NTt/+b8dsYc8tTCyYgI9HMZCW7b0Y+Ei16/ObvbfVEuG/R2jpzZ0F47yDexGRmu/W8kfAHgsz8nlkwSfMYWu4niMZVw5F35x0DNXS78u5Fd48rderplAOsRNIZxsaCBygfr19WYkdBto1pu6uiKXooAKFPZvuqW6KHQqRMhGBucnn5MUrtcHp9TJnT40OZIvb9wVkFePj975gxDtS0YOm0PKbe0mmjovbnSL17N+yEUW/g5qfcg7LSfGFc/3P//YFp2+oO4oF3WOT0A+/sAihhylZ+vC96WS/Sn9Wo4+9FZCTgzgtHM2W3njeSu7MQKkvk9u9PH37PjPvYh3uxp6qZKXN6A9xeCfsryY+mKG333RCM+/B73+GPlxYy9br7jkFBbhL3bpSV2mHQo0fHlTr1dMp9YzAYdJg5bgDyMhMYFLLPF8CQ9Lh2o5JEZihRyKkIwfyHd/fgz/MKGaSzy+fHnW/uZOr96aP9uL9kLIO/bvH4OdyywxPAG1uPMm1FOO2QiYhFRByuc6HJ6eMw1AvPGMyMW9Xk5MIvHS41MxSPoWhwepkxfAGK746x2G2Xz4eH3jvArOO5/x7CnReN4soeKM1n9q+62YUth5u4cZUmooZWL9Z+cZjrr0zR397KBlQ7fFi7qDj6HqTG6/HNoXqsWVgctfVXOZzcuIfrXBiQYmEw2d0dHWQy6TGzMBfD0uOZ1J4Gg65Hx5U69XTKHQyAOJ2hwaDjHM1KicxQqqaQmHaEACYDAaUEbn8bIjrRYkSD08uhmgkI/hvOn4yqFpyVly4cV9l21RXjhSGTImxEk9uHZf/4jik7WOfCLa+1+QSWThvBjatm6lJDU9Q7fVFbf6LZgFe2lOO5L9ruQKy6YrxwD/REx5XFm/QMErvJqQ1HHm8xCMcwG3S4/KlNTJkIXPf5gXqMyE6GyxNANTyoaxWPmxpv7nE0tRLZHZFEYkt1p045U9LxSGSGystK1ISwuPnneahp9jAIi6MNLqyYzZofREiH6mYPN4Zo3HizDjedncfhIOItLK5ChJcQISJGCPAXRr0Yu6HMSlZWYker1487Xt+G3765A7e/vi2cJY7HRnDmEUF/y0rtqGv1Mv2ZDAasnFfU4TrUxqCUcm0HpcQxz3xgkhWXTx7MjJuWYOYwGaK2UlInqk65cNXjVeRyXMQMZbMYcfvr33aIv7AYxeGRd1wwCumJlg7bPr9wEgh0UXOBUU9wy2vfagr9fOm6KfAHabRtnEmHm1/5hmmbZNHjpc1HuLIPdlcya2ts9WDDtnKmbO3nB3D7BaNR1eyNljmcHix/93tmLqvmj8cjH3zPhbo+NMsOnU7PIDZKi06DyxeMmnkMOuCKZ3kc+V+vnACLUR81f7399REs+MlQOD1tbbf/WItpY7NQ0xKImogGpJhxxdObubk8d20xhzdRhjdbjDo8Pm88th1taretlFR/lgxX7UYpzVBf/FCrCX+hFh5Z7/ShbON3HbY9XOdiQj+fmM9jntXaakFEq2EeRGtTlgFApcPDYTeUc2kN+0qUIbE/NriZtQHAuEFpzJzVwnhrmj1c2zPyspi5AMBpaTYOTSGaiwhvIg4R9XbYVkrqRJU8GMLSgtMWKctmEeIvhDboOCOXmrKryAmLUa953Gwbj/ZWpvasbHJxyI6GVg83hhp2Y2haHIPxoPBj0w9sf4kWHguy5vMDQky2MtxSzbeRGsen+xSFb4rQFFrSZKoh1EU+lf4UIirCvsgsb1JaJU1J0I4pEEkrYuPBmQUw6nkEgyiVpDLVpQglIUq7KcQyCMZQwzeIsBZKFIcQQ6GGyVCkLVWbnzItaFmJHQUD4zHrr1+2rVeAFBHNpazEjsHpZlyzeiuzf11Nk6lWLyPRhP954etOvy+9IZkCVEqLJBKjAx1PykRRW5EtXQ11sWZhMdz+AINq/s0Fo9DobLOHG3SES9mplhJz/bflnN18WamdQSasmj8evwlfAIudi9b0nC8sKobT1zZnq1GPBat5+7+yP63jWow6PHftZNS0tPksMhNN+H///J7zd/zhve+5/l69YSoIAROOrPyF2JlnrvQr5eckQacjmrAWfSE1v8i6xVMx7rSUPpyZVH+S9DF0oM6kTPR6Awz+IkAph5xw+wOa0zxWN7sZWzoAXD5pMJLCdygIgPJGNzdGnEkvvFMhsps7vQHGVOP2BzTdRVDDglc3exCggNsbgIMQOFx+Tf21erTVc/uCqG/1Ij3BhNpmiowEExxuv2ZfTpXDjQvsOUw4slKdeeai8Gag/4aIqvlFKpvc7e6JlFRE8mCAdhSy1xvA29uPMaaQR+aMw8IzhuCxD/dGy/5yBY+cUMdBs2NYjDoYDboohM9i1OHl66dgwemDoxFHFqMO904fi8FpVubim8g/MTjNilZvgME3iOYnspur+TvizAbc+GKbqWb1tZM19ae2BzYL7xOIMxuw6PmvYkwhBZrWK/IniKT1mZ+IUvOLaNkXKSlA3mMAAAxJixemVlRiBbYfa+KQE/uqm6OHQqSsbOMuLs7dZOBxEGUldviCfqZs6bQ87KlwMP0FKWXCUENj7MbvL2axG6Oz+bsN903Px+/DSOvY+S2fqUhXWWqHUYFWGJ6ZgLKSfC5e//4N7B489sH3QlSD8i6CUR/iKjHzm5GPeDN7z+Ke6WO5Me5+ewfun8GnGVXeK1k+0478nKRue+YnokT3bbTui5QUIL8xAAhRLC/Mz8boDrAClQLzgxoSY1CqFesWT2Xs0i0+L4akt+EWUuL0WLB6K4NqWPvFYcyeOJDp71ij2DTwfWUz0xYgeHf7Mfzt6olR+//+qhbh/JKsBgbzUNfiwqubf2Taun0BPPPJAQZrUeNwc3iOLYebcOt5ZgYvodf5QaFj8BK+gB9/+ddhDsVx7thsZh3Nbh83htsXhNPnxwsx/RWEfQdKvIkWB6vWZ34iSg37Ih3PUlolDwaFYn3xyhBWEd1SzZyRFsYjxNp0TT72H6bHx2MtLEYe6ZCRaFYZw4iBqXHRkFOjgeBAXSs2H2zoMLw03qRHVRgvUR3GS3xxsB7/3tvGRlp1xXjsrW7BkhjHsAiTYTHqoNfp4IrBfby46RBu/FkejHoCo57AbNDDatRz/VmMOpw9OsjsgdoYmQlmTBZgS0T2f6XUwpH7q5/geKXmF5GS0iIZlQT1cFWTgeDml9vCKFdfOxFHGzyMj2HFnELoiQ63/b3zWd1EGdxEWdjeX3o6Nh9s5jOuKTKzicJBRSGdoraicFVRGKoohFXUtqzEjrQEI26K2T9RJrVlpXYkx7Hhqk/MH49Gp4/LmnaJPRPxVnM7T7Jzz7e/hJdKSfWFZLhqB1ILXRQhLD645UxUO7wc3bKj0MXNB+uEIZ0vLCoGgKh5JMGixz1v72TCMrMTzbj9jW0dhr+qhZf+7aoJMBrasBE+fwD/E05LGVtPmU1OhMRY+/kB3HreSIDoov2Z9QRXCnAVojBUZVa3tZ8fwP+7rAhBiuj+OVw+LF33DRd2++hlRUKAXFefr8xyJnUqS4ardiC10EURwuJYoxtTh6VzfXRkkqhy8Fnd3L4gKh0ezBiXGy17f2cFF5Ypwl+Iwl/VwksrHR4uk5qonjKbnBr+Qomw+PNccZYzURiqMqsbEPLdTB2W3papbPsxYdhtlcONrqgzoalSUlLyYACgHroozmjWtZC/LJvYT5BlM+NATUv0G8jAFD7UUIRvSEkwaUZiiMJGteC59QRChEW2TYHnMOk0jatWxmEoVJ5Hlo3fey0ok86EpnYVjSIldTJJHgxoC10U+Rgiv1CON5zRnp2IshI752MAglEzh8Wow6OXFeGROYWMTyA7SY+bzs5j2j4ypxA3/zyPscOvmF2IB2cVRMNTI2NEsNuRsgieWzmXSNhopKxoUBIGJMcxaTJXzC5ETYuX8xOsmFPI+ixKQr6S2P7KSu1ITTB0uKeRTGVKZEdhLhtuqdV3oPZ8leNKX4SUVEjSxxBW5JNirJ8AQLdiD5wuL3ZWNkf9Cdk2E87/82fcJ9mNN/8UrV5/NNTQ4w9y/gk1f8Kt5+ahyR1gbPN/ujxkw498CgaAq579kmurRICnxhlx/dotmsZ98bopCAZpNFzVG/Th92/t5vwEq68pBiHocE8jN8xjfTkmk56p0xnfgej5KseVvgipU0nSx6BBaqGL3RnOGGc1MVnivvihVmj7rm31YOqw9Gio4Tvbjmn2Jzg8Ac42X9HkxiWFbX4MUX9uH48AF/kO1MatUKC9RRhvAKhpYf0JalLLVBarzvgOtISmSl+ElFRI8mDoQ6mhn09LtWDzwbqYpDJ8PbX7CSK/yMAUK9PfwBRtPpUQ3lvbvY0shb1eHR/efViG7sZanMyYDCmpzkhehexDDUqJw6/OYVNxPnZ5Af67rwELVm/Gr175BgtWb0aNw4Obfs7WS4k3Y8UcNi2oKGXnI3MKsbeqhenvx3oXh0xYVmrHCEXbAOVTcQ7P4DEUoTsLeqasYGBSjyMnuhtrcTJjMqSkOiPpY+hDiWzary2eigXPafMnLJ2WhxYP60/48+VFCMT6EyjFVYL7Ey9fPwWBII1+i7AY9bj5la85n8Dj88bB4wOTJvPicTk42uCLth2ZHQ+b2dzjPhqRtPgO+rI/Kan+qj7zMRBCVgOYDqCaUmqPKf8VgJsB+AH8g1J6R7j8LgDXAQgAWEIp/WdPzq+3pcyq5Q3w+OuqZm08ptA9Ad6f4PD4YDUaEKRAkFK4vGLUdXmjGzlJFoAAOkJwuM4p9Al8X9nK3Tuwn5am+S6Hsqy7w0G7G2txMmMypKS0qqd9DM8DWAVgbaSAEPJzAKUACimlHkJIZrh8LIB5APIB5AL4iBAyklIa6OE59opEWbUenMWjpEV2bjV7vfL36aTBSahyeHHv+rbMYmWldkwanIQth5uYtjk2czQyyWIMwe5EYyQJkNgZCV2zuctwUCmpE0M96mOglH4CoF5RfCOAhymlnnCd6nB5KYBXKaUeSulBAPsBFPfk/HpTuyqaoocCEPrU/vu3duABhQ3foKMc6np4RjwevpT1J/xhVgFGZLA+gVvOG81hwe9dvxO/Pm8UU2/ptDxQQpl6B6qbsXRaHlfPatJxZfouvjWH6lqjh0Jk3Ftf+xaH6lq71qGUlFSPqC+ikkYCOJMQ8iAAN4DfUEq/AjAAwKaYekfDZZwIIYsBLAaAQYMG9exsu0lqWbW8/iDejUE/H6prwdH6FgaJ/d99VZgwJI3DePv9QeTEYKgrVbAbdS1eDu2dm2xl6h1t8uCNrUe5evOLB3Fl4wclY0h6500tMhxUSurEUF8cDAYAKQCmApgM4DVCyDCEslgqJfSMU0qfAvAUEHI+99A8NUuL3Vwtq1ZWYogWGokBSE+w4KnPDuPxfx9k6r1TlItGZwDeAIXXH4TfH4ROR0AIifoJslWwGylxRg7tnRLHmoj0RIwA9weDXJkMB5WSOrnVF+GqRwG8SUPaDCAIID1cHkuPHwjgWB/Mr1OK2M0vfvxTzH/6S1z8+Kd4f1clggoCn1pWrUa3l2lb3ezm6j1zzQR8c6QZV4dDTq9evRnv7KzAP7+rxFXPfombX/4GVz77JRpcPmGWuEAwyJdRtmx4ZgIevYwP1SwcmCTDQaWkTjH1eLgqIWQIgI2RqCRCyC8A5FJK7yWEjATwMYBBAMYCeBkhv0JuuDyvI+dzX4erdgajEIlKipiDkuOMuODPfNv3lpwJh9sXref1B6M5oGPribDgb954Olo8gah5aVCKGc98egDn5g9ATbMbGYkWfLSrHAvOGKYJHw50b8ipDAeVkuof6stw1VcAnA0gnRByFMB9AFYDWE0I2QnAC+AaGjqddhFCXgOwG6Ew1ptOhIikztjNlVm11JAYVc3uDpEYaljwg7VOBn/xxQ+1eOa/P+KZ//7I1D03P7fLIafHIxkOKiXV/9WjBwOldL7KX12lUv9BAA/23Iy6X8djN8+yWfCX+XZkJCaELpDZLKhxtHBts21mITpDhL9QoqmzbBZcPjEHMycMQm2zBxmJZrz19ZE+s+tH4HiVDjdybBYUCOB4gMRfS0n1pSQr6TilFeksUlqCAa1eHW4L33Ruw0uwjyU/O1GIyc6wtbGM1NDUOQlmTBqSgUXPf8W0zUnofIrM45XXG8Db249xOO2ZhbnM4SDvO0hJ9a0kEqMb1FW7uVq6z7WLihkK67YfGzD3qU1cvVdvmAp/kLaLpv7qYJ3QP/HComJMjhmjN7TlUL0Q9/3idVMYkqrEX0tJ9bwkdruH1VW7uVq6zyqHhylTuwNR5XDjAntOu2Oo3W1QjtEbqlTxxyhTdsr7DlJSfStJV+1DRdJ9xirkJ2DNPJE7EMp62Ukd+wmyNY7RG4qk7OTnwvtFhOu1WXCgpgVf/FCLAzUtXEiwlJRU90geDH2o0dnxwnsHo7NZ/4TaHYj8nCSuz66O0RuKpOxk5iLwi4juO6y6Yjx2VzR3eF9ESkrq+CV9DH0sh8uN7ytbo/cORmfHw2blvwko70Dk54TuHXSkzQfrcPvr2zic9iNzxjF+jN6SlpSdAO+3oRS45Anpd5CS6i5JH0M/ls1qQfHQjk1Cfn+IqxSLxNByMFQ5PEKcdl/4GABtKTsB3m+jdudD+h2kpLpf8mA4AeR2+7FhRwUXrlpSkAOLpf1HmKXCT+oLH8PxSHKWpKR6T9LHcAJoR0VT9FAAwjjtDTuxo6Kpg5ZAQbZN6GMoyLb16Jy7W5KzJCXVe5LfGE4AHU/IqdVqxAx7Noakx0X9GAXZNlitxg7b9ifpdAQX5mdjdAyiXN6GlpLqGcmDISwRggFAn2AZ3G4/dlQ0odLhQbbNjNwksRlFqznIajX2iaO5uyU5S1JSvSN5MECMYFh1xXh4/bTXsQwif8IjcwqxrNSOe9azPoYCDeGqUlJSUp2VDFeFGMGwZNoIPPXJgV4Pj1RDWKxbPBVef7DNHJST1KHjWUpKSkpNMly1A4kQDEGKPgmPVPMn/FjvwvRxuSqtpKSkpLpPMioJYgSDnkCIZejp8Mj+hLCQkpI6NSUPBohDIQsGJvVJeGRBTpI4vFT6E6SkpHpJ0scQlgidDXRvWkutikQlSX+ClJRUT0n6GDRILRSyL8IjLRZDr+dKkJKSkopImpKkpKSkpBjJg0FKSkpKipE8GKSkpKSkGMmDQUpKSkqKkTwYpKSkpKQYnfDhqoSQGgCHu7HLdAC13dhfX0muo39JrqN/Sa4DGEwpzRD9xQl/MHS3CCFb1GJ7TyTJdfQvyXX0L8l1tC9pSpKSkpKSYiQPBikpKSkpRvJg4PVUX0+gmyTX0b8k19G/JNfRjqSPQUpKSkqKkfzGICUlJSXF6JQ/GAghhwghOwgh3xJCtoTLUgkhHxJC9oX/n9LX8+xIhJBkQsjrhJDvCSHfEUJOP9HWQQgZFX4Okf8chJBfn4DruIUQsosQspMQ8gohxHKirQEACCFLw2vYRQj5dbis36+DELKaEFJNCNkZU6Y6b0LIXYSQ/YSQPYSQC/pm1rxU1nFZ+HkECSGTFPW7bR2n/MEQ1s8ppUUxYV93AviYUpoH4OPwz/1dKwG8TykdDWAcgO9wgq2DUron/ByKAEwE4ATwFk6gdRBCBgBYAmASpdQOQA9gHk6gNQAAIcQO4AYAxQi9T9MJIXk4MdbxPIALFWXCeRNCxiL0fPLDbf5KCNH33lTb1fPg17ETwKUAPokt7O51yINBrFIAa8J/XgNgZt9NpWMRQmwAzgLwLABQSr2U0kacYOtQaBqAHyilh3HircMAwEoIMQCIA3AMJ94axgDYRCl1Ukr9AP4DYBZOgHVQSj8BUK8oVpt3KYBXKaUeSulBAPsROgz7XKJ1UEq/o5TuEVTv1nXIgwGgAD4ghGwlhCwOl2VRSisAIPz/zD6bnTYNA1AD4DlCyDeEkGcIIfE48dYRq3kAXgn/+YRZB6W0HMD/A3AEQAWAJkrpBziB1hDWTgBnEULSCCFxAC4GcBpOvHVEpDbvAQB+jKl3NFx2oqlb1yEPBuAMSukEABcBuIkQclZfT6gLMgCYAOBJSul4AK3on1/xNYkQYgJQAuDvfT2Xzipsuy4FMBRALoB4QshVfTurzotS+h2APwL4EMD7ALYB8PfppHpGopSMJ2KoZreu45Q/GCilx8L/r0bInl0MoIoQkgMA4f9X990MNekogKOU0i/DP7+O0EFxoq0joosAfE0prQr/fCKt41wABymlNZRSH4A3AfwEJ9YaAACU0mcppRMopWchZNLYhxNwHWGpzfsoQt+EIhqIkOnvRFO3ruOUPhgIIfGEkMTInwGcj9BX6A0ArglXuwbA+r6ZoTZRSisB/EgIGRUumgZgN06wdcRoPtrMSMCJtY4jAKYSQuIIIQShZ/EdTqw1AAAIIZnh/w9CyOH5Ck7AdYSlNu8NAOYRQsyEkKEA8gBs7oP5Ha+6dx2U0lP2P4Rs89vC/+0C8PtweRpCkQv7wv9P7eu5alhLEYAtALYDeBtAygm6jjgAdQCSYspOqHUAeADA9wh9yHgBgPlEW0N4HZ8i9AFjG4BpJ8qzQOgAqwDgQ+iT9HXtzRvA7wH8AGAPgIv6ev4drGNW+M8eAFUA/tkT65A3n6WkpKSkGJ3SpiQpKSkpKV7yYJCSkpKSYiQPBikpKSkpRvJgkJKSkpJiJA8GKSkpKSlG8mCQkpKSkmIkDwYpqU4qzKIa20Gd5wkhcwTlQwghV3TQ9lpCyKrjnaeUVFclDwYpqU6KUno9pXR3F5sPAdDuwSAl1deSB4PUKStCyB2EkCXhP/+JEPKv8J+nEUJeJIScTwj5ghDyNSHk74SQhPDf/18kSQoh5DpCyN5w2dOKT/pnEUI+J4QciPn28DCAM8OJiG7RMMdLwnNIJ4QMJ4RsIoR8RQgpI4S0dOuGSEmFJQ8GqVNZnwA4M/znSQASCCFGAD8FsAPA3QDOpSH67hYAt8Y2JoTkArgHwFQA5wEYreg/J9zXdIQOBCBEvf2UhhIS/am9yRFCZoXrX0wprUUoGdNKSulknJigN6kTRPJgkDqVtRXAxDBI0QPgC4QOiDMBuACMBfBfQsi3CIHXBivaFwP4D6W0noZIqkpM+NuU0mDY7JTVybn9HMBvAVxCKW0Il50eM8bLnexPSkqzDH09ASmpvhKl1EcIOQRgIYDPEQIQ/hzAcAAHAXxIKZ3fThciBn6sPJ2oq9QBhCCPIxH6tiIl1WuS3xikTnV9AuA34f9/CuAXAL4FsAnAGYSQEQAQxmiPVLTdDOBnhJCUcBrP2RrGawaQqKHeYYRQ12sJIfnhsk0xY8zT0IeUVJckDwapU12fIuQL+IKGEgO5EfIB1AC4FsArhJDtCP1SZnwINJTG8w8AvgTwEUKI6qYOxtsOwE8I2daR85mGcvteCeDvhJDhAH4N4FZCyObwnDsaS0qqS5LYbSmp4xAhJIFS2hL+xvAWgNWU0rd6aKw4AC5KKSWEzAMwn1Ja2hNjSZ3akj4GKanj0/2EkHMBWAB8gFCSpJ7SRACrwpnhGgEs6sGxpE5hyW8MUlJ9JELIBQD+qCg+SCmd1RfzkZKKSB4MUlJSUlKMpPNZSkpKSoqRPBikpKSkpBjJg0FKSkpKipE8GKSkpKSkGMmDQUpKSkqK0f8HtYc9nmdyPT0AAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "sns.scatterplot(data=df,x='weight_kg',y='height_cm')\n",
+    "#vemos que hay una correlacion entre peso y altura"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "6c20cb97",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Unnamed: 0</th>\n",
+       "      <th>Unnamed: 0.1</th>\n",
+       "      <th>sofifa_id</th>\n",
+       "      <th>short_name</th>\n",
+       "      <th>long_name</th>\n",
+       "      <th>player_positions</th>\n",
+       "      <th>overall</th>\n",
+       "      <th>potential</th>\n",
+       "      <th>value_eur</th>\n",
+       "      <th>wage_eur</th>\n",
+       "      <th>age</th>\n",
+       "      <th>dob</th>\n",
+       "      <th>height_cm</th>\n",
+       "      <th>weight_kg</th>\n",
+       "      <th>club_team_id</th>\n",
+       "      <th>club_name</th>\n",
+       "      <th>league_name</th>\n",
+       "      <th>league_level</th>\n",
+       "      <th>club_position</th>\n",
+       "      <th>club_jersey_number</th>\n",
+       "      <th>club_loaned_from</th>\n",
+       "      <th>club_joined</th>\n",
+       "      <th>club_contract_valid_until</th>\n",
+       "      <th>nationality_id</th>\n",
+       "      <th>nationality_name</th>\n",
+       "      <th>nation_team_id</th>\n",
+       "      <th>nation_position</th>\n",
+       "      <th>nation_jersey_number</th>\n",
+       "      <th>preferred_foot</th>\n",
+       "      <th>weak_foot</th>\n",
+       "      <th>skill_moves</th>\n",
+       "      <th>international_reputation</th>\n",
+       "      <th>work_rate</th>\n",
+       "      <th>body_type</th>\n",
+       "      <th>real_face</th>\n",
+       "      <th>release_clause_eur</th>\n",
+       "      <th>player_tags</th>\n",
+       "      <th>player_traits</th>\n",
+       "      <th>pace</th>\n",
+       "      <th>shooting</th>\n",
+       "      <th>passing</th>\n",
+       "      <th>dribbling</th>\n",
+       "      <th>defending</th>\n",
+       "      <th>physic</th>\n",
+       "      <th>attacking_crossing</th>\n",
+       "      <th>attacking_finishing</th>\n",
+       "      <th>attacking_heading_accuracy</th>\n",
+       "      <th>attacking_short_passing</th>\n",
+       "      <th>attacking_volleys</th>\n",
+       "      <th>skill_dribbling</th>\n",
+       "      <th>skill_curve</th>\n",
+       "      <th>skill_fk_accuracy</th>\n",
+       "      <th>skill_long_passing</th>\n",
+       "      <th>skill_ball_control</th>\n",
+       "      <th>movement_acceleration</th>\n",
+       "      <th>movement_sprint_speed</th>\n",
+       "      <th>movement_agility</th>\n",
+       "      <th>movement_reactions</th>\n",
+       "      <th>movement_balance</th>\n",
+       "      <th>power_shot_power</th>\n",
+       "      <th>power_jumping</th>\n",
+       "      <th>power_stamina</th>\n",
+       "      <th>power_strength</th>\n",
+       "      <th>power_long_shots</th>\n",
+       "      <th>mentality_aggression</th>\n",
+       "      <th>mentality_interceptions</th>\n",
+       "      <th>mentality_positioning</th>\n",
+       "      <th>mentality_vision</th>\n",
+       "      <th>mentality_penalties</th>\n",
+       "      <th>mentality_composure</th>\n",
+       "      <th>defending_marking_awareness</th>\n",
+       "      <th>defending_standing_tackle</th>\n",
+       "      <th>defending_sliding_tackle</th>\n",
+       "      <th>goalkeeping_diving</th>\n",
+       "      <th>goalkeeping_handling</th>\n",
+       "      <th>goalkeeping_kicking</th>\n",
+       "      <th>goalkeeping_positioning</th>\n",
+       "      <th>goalkeeping_reflexes</th>\n",
+       "      <th>goalkeeping_speed</th>\n",
+       "      <th>ls</th>\n",
+       "      <th>st</th>\n",
+       "      <th>rs</th>\n",
+       "      <th>lw</th>\n",
+       "      <th>lf</th>\n",
+       "      <th>cf</th>\n",
+       "      <th>rf</th>\n",
+       "      <th>rw</th>\n",
+       "      <th>lam</th>\n",
+       "      <th>cam</th>\n",
+       "      <th>ram</th>\n",
+       "      <th>lm</th>\n",
+       "      <th>lcm</th>\n",
+       "      <th>cm</th>\n",
+       "      <th>rcm</th>\n",
+       "      <th>rm</th>\n",
+       "      <th>lwb</th>\n",
+       "      <th>ldm</th>\n",
+       "      <th>cdm</th>\n",
+       "      <th>rdm</th>\n",
+       "      <th>rwb</th>\n",
+       "      <th>lb</th>\n",
+       "      <th>lcb</th>\n",
+       "      <th>cb</th>\n",
+       "      <th>rcb</th>\n",
+       "      <th>rb</th>\n",
+       "      <th>gk</th>\n",
+       "      <th>año_version</th>\n",
+       "      <th>progresion_anual</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>7422</th>\n",
+       "      <td>9377</td>\n",
+       "      <td>9377</td>\n",
+       "      <td>156321</td>\n",
+       "      <td>A. Akinfenwa</td>\n",
+       "      <td>Saheed Adebayo Akinfenwa</td>\n",
+       "      <td>ST</td>\n",
+       "      <td>62</td>\n",
+       "      <td>62</td>\n",
+       "      <td>275000.0</td>\n",
+       "      <td>2000.0</td>\n",
+       "      <td>32</td>\n",
+       "      <td>1982-05-10</td>\n",
+       "      <td>178</td>\n",
+       "      <td>110</td>\n",
+       "      <td>112259.0</td>\n",
+       "      <td>AFC Wimbledon</td>\n",
+       "      <td>English League Two</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>RS</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2014-06-20</td>\n",
+       "      <td>2015.0</td>\n",
+       "      <td>14</td>\n",
+       "      <td>England</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Right</td>\n",
+       "      <td>3</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>Low/Low</td>\n",
+       "      <td>Stocky (170-185)</td>\n",
+       "      <td>No</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>#Strength</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>50.0</td>\n",
+       "      <td>59.0</td>\n",
+       "      <td>53.0</td>\n",
+       "      <td>61.0</td>\n",
+       "      <td>34.0</td>\n",
+       "      <td>78.0</td>\n",
+       "      <td>38</td>\n",
+       "      <td>63</td>\n",
+       "      <td>68</td>\n",
+       "      <td>59</td>\n",
+       "      <td>58</td>\n",
+       "      <td>60</td>\n",
+       "      <td>49</td>\n",
+       "      <td>41</td>\n",
+       "      <td>49</td>\n",
+       "      <td>69</td>\n",
+       "      <td>45</td>\n",
+       "      <td>54</td>\n",
+       "      <td>41</td>\n",
+       "      <td>59</td>\n",
+       "      <td>70</td>\n",
+       "      <td>54</td>\n",
+       "      <td>57</td>\n",
+       "      <td>59</td>\n",
+       "      <td>97</td>\n",
+       "      <td>49</td>\n",
+       "      <td>59</td>\n",
+       "      <td>25</td>\n",
+       "      <td>67</td>\n",
+       "      <td>64</td>\n",
+       "      <td>66</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>25</td>\n",
+       "      <td>40</td>\n",
+       "      <td>25</td>\n",
+       "      <td>13</td>\n",
+       "      <td>6</td>\n",
+       "      <td>14</td>\n",
+       "      <td>5</td>\n",
+       "      <td>15</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>62</td>\n",
+       "      <td>62</td>\n",
+       "      <td>62</td>\n",
+       "      <td>56</td>\n",
+       "      <td>60</td>\n",
+       "      <td>60</td>\n",
+       "      <td>60</td>\n",
+       "      <td>56</td>\n",
+       "      <td>60</td>\n",
+       "      <td>60</td>\n",
+       "      <td>60</td>\n",
+       "      <td>56</td>\n",
+       "      <td>56</td>\n",
+       "      <td>56</td>\n",
+       "      <td>56</td>\n",
+       "      <td>56</td>\n",
+       "      <td>45</td>\n",
+       "      <td>52</td>\n",
+       "      <td>52</td>\n",
+       "      <td>52</td>\n",
+       "      <td>45</td>\n",
+       "      <td>44</td>\n",
+       "      <td>48</td>\n",
+       "      <td>48</td>\n",
+       "      <td>48</td>\n",
+       "      <td>44</td>\n",
+       "      <td>13</td>\n",
+       "      <td>2015</td>\n",
+       "      <td>0.032258</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>18450</th>\n",
+       "      <td>24934</td>\n",
+       "      <td>8779</td>\n",
+       "      <td>156321</td>\n",
+       "      <td>A. Akinfenwa</td>\n",
+       "      <td>Saheed Adebayo Akinfenwa</td>\n",
+       "      <td>ST</td>\n",
+       "      <td>64</td>\n",
+       "      <td>64</td>\n",
+       "      <td>300000.0</td>\n",
+       "      <td>2000.0</td>\n",
+       "      <td>33</td>\n",
+       "      <td>1982-05-10</td>\n",
+       "      <td>178</td>\n",
+       "      <td>110</td>\n",
+       "      <td>112259.0</td>\n",
+       "      <td>AFC Wimbledon</td>\n",
+       "      <td>English League Two</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>LS</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2014-06-20</td>\n",
+       "      <td>2016.0</td>\n",
+       "      <td>14</td>\n",
+       "      <td>England</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Right</td>\n",
+       "      <td>3</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>Low/Low</td>\n",
+       "      <td>Unique</td>\n",
+       "      <td>Yes</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>#Strength</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>49.0</td>\n",
+       "      <td>60.0</td>\n",
+       "      <td>54.0</td>\n",
+       "      <td>62.0</td>\n",
+       "      <td>35.0</td>\n",
+       "      <td>81.0</td>\n",
+       "      <td>39</td>\n",
+       "      <td>64</td>\n",
+       "      <td>69</td>\n",
+       "      <td>60</td>\n",
+       "      <td>59</td>\n",
+       "      <td>61</td>\n",
+       "      <td>50</td>\n",
+       "      <td>42</td>\n",
+       "      <td>50</td>\n",
+       "      <td>71</td>\n",
+       "      <td>45</td>\n",
+       "      <td>52</td>\n",
+       "      <td>32</td>\n",
+       "      <td>60</td>\n",
+       "      <td>70</td>\n",
+       "      <td>55</td>\n",
+       "      <td>57</td>\n",
+       "      <td>69</td>\n",
+       "      <td>98</td>\n",
+       "      <td>50</td>\n",
+       "      <td>60</td>\n",
+       "      <td>17</td>\n",
+       "      <td>68</td>\n",
+       "      <td>65</td>\n",
+       "      <td>67</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>32</td>\n",
+       "      <td>41</td>\n",
+       "      <td>24</td>\n",
+       "      <td>14</td>\n",
+       "      <td>7</td>\n",
+       "      <td>15</td>\n",
+       "      <td>6</td>\n",
+       "      <td>16</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>64</td>\n",
+       "      <td>64</td>\n",
+       "      <td>64</td>\n",
+       "      <td>58</td>\n",
+       "      <td>62</td>\n",
+       "      <td>62</td>\n",
+       "      <td>62</td>\n",
+       "      <td>58</td>\n",
+       "      <td>61</td>\n",
+       "      <td>61</td>\n",
+       "      <td>61</td>\n",
+       "      <td>59</td>\n",
+       "      <td>59</td>\n",
+       "      <td>59</td>\n",
+       "      <td>59</td>\n",
+       "      <td>59</td>\n",
+       "      <td>46</td>\n",
+       "      <td>50</td>\n",
+       "      <td>50</td>\n",
+       "      <td>50</td>\n",
+       "      <td>46</td>\n",
+       "      <td>44</td>\n",
+       "      <td>49</td>\n",
+       "      <td>49</td>\n",
+       "      <td>49</td>\n",
+       "      <td>44</td>\n",
+       "      <td>16</td>\n",
+       "      <td>2016</td>\n",
+       "      <td>0.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>31262</th>\n",
+       "      <td>42396</td>\n",
+       "      <td>10618</td>\n",
+       "      <td>156321</td>\n",
+       "      <td>A. Akinfenwa</td>\n",
+       "      <td>Saheed Adebayo Akinfenwa</td>\n",
+       "      <td>ST</td>\n",
+       "      <td>64</td>\n",
+       "      <td>64</td>\n",
+       "      <td>230000.0</td>\n",
+       "      <td>7000.0</td>\n",
+       "      <td>34</td>\n",
+       "      <td>1982-05-10</td>\n",
+       "      <td>178</td>\n",
+       "      <td>110</td>\n",
+       "      <td>1933.0</td>\n",
+       "      <td>Wycombe Wanderers</td>\n",
+       "      <td>English League Two</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>SUB</td>\n",
+       "      <td>20.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2016-07-10</td>\n",
+       "      <td>2017.0</td>\n",
+       "      <td>14</td>\n",
+       "      <td>England</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Right</td>\n",
+       "      <td>3</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>Low/Low</td>\n",
+       "      <td>Unique</td>\n",
+       "      <td>Yes</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>#Strength</td>\n",
+       "      <td>Backs Into Player, Target Forward</td>\n",
+       "      <td>45.0</td>\n",
+       "      <td>60.0</td>\n",
+       "      <td>51.0</td>\n",
+       "      <td>60.0</td>\n",
+       "      <td>35.0</td>\n",
+       "      <td>80.0</td>\n",
+       "      <td>39</td>\n",
+       "      <td>64</td>\n",
+       "      <td>68</td>\n",
+       "      <td>56</td>\n",
+       "      <td>59</td>\n",
+       "      <td>59</td>\n",
+       "      <td>50</td>\n",
+       "      <td>42</td>\n",
+       "      <td>47</td>\n",
+       "      <td>69</td>\n",
+       "      <td>41</td>\n",
+       "      <td>49</td>\n",
+       "      <td>29</td>\n",
+       "      <td>61</td>\n",
+       "      <td>70</td>\n",
+       "      <td>57</td>\n",
+       "      <td>50</td>\n",
+       "      <td>63</td>\n",
+       "      <td>98</td>\n",
+       "      <td>50</td>\n",
+       "      <td>63</td>\n",
+       "      <td>17</td>\n",
+       "      <td>68</td>\n",
+       "      <td>62</td>\n",
+       "      <td>66</td>\n",
+       "      <td>70.0</td>\n",
+       "      <td>33</td>\n",
+       "      <td>40</td>\n",
+       "      <td>24</td>\n",
+       "      <td>14</td>\n",
+       "      <td>7</td>\n",
+       "      <td>15</td>\n",
+       "      <td>6</td>\n",
+       "      <td>16</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>63+1</td>\n",
+       "      <td>63+1</td>\n",
+       "      <td>63+1</td>\n",
+       "      <td>57</td>\n",
+       "      <td>61</td>\n",
+       "      <td>61</td>\n",
+       "      <td>61</td>\n",
+       "      <td>57</td>\n",
+       "      <td>59+1</td>\n",
+       "      <td>59+1</td>\n",
+       "      <td>59+1</td>\n",
+       "      <td>57+1</td>\n",
+       "      <td>56+1</td>\n",
+       "      <td>56+1</td>\n",
+       "      <td>56+1</td>\n",
+       "      <td>57+1</td>\n",
+       "      <td>44+1</td>\n",
+       "      <td>48+1</td>\n",
+       "      <td>48+1</td>\n",
+       "      <td>48+1</td>\n",
+       "      <td>44+1</td>\n",
+       "      <td>43+1</td>\n",
+       "      <td>48+1</td>\n",
+       "      <td>48+1</td>\n",
+       "      <td>48+1</td>\n",
+       "      <td>43+1</td>\n",
+       "      <td>16+1</td>\n",
+       "      <td>2017</td>\n",
+       "      <td>0.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>43850</th>\n",
+       "      <td>60285</td>\n",
+       "      <td>10911</td>\n",
+       "      <td>156321</td>\n",
+       "      <td>A. Akinfenwa</td>\n",
+       "      <td>Saheed Adebayo Akinfenwa</td>\n",
+       "      <td>ST</td>\n",
+       "      <td>64</td>\n",
+       "      <td>64</td>\n",
+       "      <td>210000.0</td>\n",
+       "      <td>5000.0</td>\n",
+       "      <td>35</td>\n",
+       "      <td>1982-05-10</td>\n",
+       "      <td>178</td>\n",
+       "      <td>110</td>\n",
+       "      <td>1933.0</td>\n",
+       "      <td>Wycombe Wanderers</td>\n",
+       "      <td>English League Two</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>ST</td>\n",
+       "      <td>20.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2016-07-10</td>\n",
+       "      <td>2018.0</td>\n",
+       "      <td>14</td>\n",
+       "      <td>England</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Right</td>\n",
+       "      <td>3</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>Low/Low</td>\n",
+       "      <td>Unique</td>\n",
+       "      <td>Yes</td>\n",
+       "      <td>368000.0</td>\n",
+       "      <td>#Strength</td>\n",
+       "      <td>Power Header, Backs Into Player, Target Forward</td>\n",
+       "      <td>45.0</td>\n",
+       "      <td>61.0</td>\n",
+       "      <td>51.0</td>\n",
+       "      <td>56.0</td>\n",
+       "      <td>35.0</td>\n",
+       "      <td>80.0</td>\n",
+       "      <td>39</td>\n",
+       "      <td>64</td>\n",
+       "      <td>71</td>\n",
+       "      <td>56</td>\n",
+       "      <td>59</td>\n",
+       "      <td>52</td>\n",
+       "      <td>50</td>\n",
+       "      <td>42</td>\n",
+       "      <td>47</td>\n",
+       "      <td>69</td>\n",
+       "      <td>41</td>\n",
+       "      <td>49</td>\n",
+       "      <td>29</td>\n",
+       "      <td>61</td>\n",
+       "      <td>70</td>\n",
+       "      <td>61</td>\n",
+       "      <td>50</td>\n",
+       "      <td>63</td>\n",
+       "      <td>98</td>\n",
+       "      <td>51</td>\n",
+       "      <td>63</td>\n",
+       "      <td>17</td>\n",
+       "      <td>68</td>\n",
+       "      <td>62</td>\n",
+       "      <td>66</td>\n",
+       "      <td>70.0</td>\n",
+       "      <td>33</td>\n",
+       "      <td>40</td>\n",
+       "      <td>24</td>\n",
+       "      <td>14</td>\n",
+       "      <td>7</td>\n",
+       "      <td>15</td>\n",
+       "      <td>6</td>\n",
+       "      <td>16</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>63+1</td>\n",
+       "      <td>63+1</td>\n",
+       "      <td>63+1</td>\n",
+       "      <td>56</td>\n",
+       "      <td>60</td>\n",
+       "      <td>60</td>\n",
+       "      <td>60</td>\n",
+       "      <td>56</td>\n",
+       "      <td>58+1</td>\n",
+       "      <td>58+1</td>\n",
+       "      <td>58+1</td>\n",
+       "      <td>56+1</td>\n",
+       "      <td>56+1</td>\n",
+       "      <td>56+1</td>\n",
+       "      <td>56+1</td>\n",
+       "      <td>56+1</td>\n",
+       "      <td>44+1</td>\n",
+       "      <td>48+1</td>\n",
+       "      <td>48+1</td>\n",
+       "      <td>48+1</td>\n",
+       "      <td>44+1</td>\n",
+       "      <td>43+1</td>\n",
+       "      <td>48+1</td>\n",
+       "      <td>48+1</td>\n",
+       "      <td>48+1</td>\n",
+       "      <td>43+1</td>\n",
+       "      <td>16+1</td>\n",
+       "      <td>2018</td>\n",
+       "      <td>0.031250</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>55238</th>\n",
+       "      <td>76015</td>\n",
+       "      <td>8687</td>\n",
+       "      <td>156321</td>\n",
+       "      <td>A. Akinfenwa</td>\n",
+       "      <td>Saheed Adebayo Akinfenwa</td>\n",
+       "      <td>ST</td>\n",
+       "      <td>66</td>\n",
+       "      <td>66</td>\n",
+       "      <td>230000.0</td>\n",
+       "      <td>3000.0</td>\n",
+       "      <td>36</td>\n",
+       "      <td>1982-05-10</td>\n",
+       "      <td>178</td>\n",
+       "      <td>110</td>\n",
+       "      <td>1933.0</td>\n",
+       "      <td>Wycombe Wanderers</td>\n",
+       "      <td>English League One</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>ST</td>\n",
+       "      <td>20.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2016-07-10</td>\n",
+       "      <td>2022.0</td>\n",
+       "      <td>14</td>\n",
+       "      <td>England</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Right</td>\n",
+       "      <td>3</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>Low/Low</td>\n",
+       "      <td>Unique</td>\n",
+       "      <td>Yes</td>\n",
+       "      <td>403000.0</td>\n",
+       "      <td>#Strength</td>\n",
+       "      <td>Injury Free, Power Header, Backs Into Player, ...</td>\n",
+       "      <td>44.0</td>\n",
+       "      <td>64.0</td>\n",
+       "      <td>53.0</td>\n",
+       "      <td>57.0</td>\n",
+       "      <td>33.0</td>\n",
+       "      <td>83.0</td>\n",
+       "      <td>39</td>\n",
+       "      <td>66</td>\n",
+       "      <td>71</td>\n",
+       "      <td>59</td>\n",
+       "      <td>59</td>\n",
+       "      <td>52</td>\n",
+       "      <td>50</td>\n",
+       "      <td>42</td>\n",
+       "      <td>47</td>\n",
+       "      <td>69</td>\n",
+       "      <td>38</td>\n",
+       "      <td>49</td>\n",
+       "      <td>35</td>\n",
+       "      <td>61</td>\n",
+       "      <td>71</td>\n",
+       "      <td>70</td>\n",
+       "      <td>49</td>\n",
+       "      <td>77</td>\n",
+       "      <td>97</td>\n",
+       "      <td>54</td>\n",
+       "      <td>66</td>\n",
+       "      <td>17</td>\n",
+       "      <td>71</td>\n",
+       "      <td>62</td>\n",
+       "      <td>66</td>\n",
+       "      <td>70.0</td>\n",
+       "      <td>27</td>\n",
+       "      <td>40</td>\n",
+       "      <td>24</td>\n",
+       "      <td>14</td>\n",
+       "      <td>7</td>\n",
+       "      <td>15</td>\n",
+       "      <td>6</td>\n",
+       "      <td>16</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>65+1</td>\n",
+       "      <td>65+1</td>\n",
+       "      <td>65+1</td>\n",
+       "      <td>57</td>\n",
+       "      <td>61</td>\n",
+       "      <td>61</td>\n",
+       "      <td>61</td>\n",
+       "      <td>57</td>\n",
+       "      <td>59+1</td>\n",
+       "      <td>59+1</td>\n",
+       "      <td>59+1</td>\n",
+       "      <td>57+1</td>\n",
+       "      <td>58+1</td>\n",
+       "      <td>58+1</td>\n",
+       "      <td>58+1</td>\n",
+       "      <td>57+1</td>\n",
+       "      <td>45+1</td>\n",
+       "      <td>49+1</td>\n",
+       "      <td>49+1</td>\n",
+       "      <td>49+1</td>\n",
+       "      <td>45+1</td>\n",
+       "      <td>44+1</td>\n",
+       "      <td>48+1</td>\n",
+       "      <td>48+1</td>\n",
+       "      <td>48+1</td>\n",
+       "      <td>44+1</td>\n",
+       "      <td>16+1</td>\n",
+       "      <td>2019</td>\n",
+       "      <td>-0.015152</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>69286</th>\n",
+       "      <td>95396</td>\n",
+       "      <td>9983</td>\n",
+       "      <td>156321</td>\n",
+       "      <td>A. Akinfenwa</td>\n",
+       "      <td>Saheed Adebayo Akinfenwa</td>\n",
+       "      <td>ST</td>\n",
+       "      <td>65</td>\n",
+       "      <td>65</td>\n",
+       "      <td>160000.0</td>\n",
+       "      <td>2000.0</td>\n",
+       "      <td>37</td>\n",
+       "      <td>1982-05-10</td>\n",
+       "      <td>178</td>\n",
+       "      <td>110</td>\n",
+       "      <td>1933.0</td>\n",
+       "      <td>Wycombe Wanderers</td>\n",
+       "      <td>English League One</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>ST</td>\n",
+       "      <td>20.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2016-07-10</td>\n",
+       "      <td>2020.0</td>\n",
+       "      <td>14</td>\n",
+       "      <td>England</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Right</td>\n",
+       "      <td>3</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>Low/Low</td>\n",
+       "      <td>Unique</td>\n",
+       "      <td>Yes</td>\n",
+       "      <td>333000.0</td>\n",
+       "      <td>#Strength</td>\n",
+       "      <td>Solid Player, Power Header</td>\n",
+       "      <td>43.0</td>\n",
+       "      <td>63.0</td>\n",
+       "      <td>54.0</td>\n",
+       "      <td>56.0</td>\n",
+       "      <td>35.0</td>\n",
+       "      <td>81.0</td>\n",
+       "      <td>44</td>\n",
+       "      <td>64</td>\n",
+       "      <td>72</td>\n",
+       "      <td>60</td>\n",
+       "      <td>59</td>\n",
+       "      <td>52</td>\n",
+       "      <td>50</td>\n",
+       "      <td>42</td>\n",
+       "      <td>51</td>\n",
+       "      <td>67</td>\n",
+       "      <td>37</td>\n",
+       "      <td>48</td>\n",
+       "      <td>35</td>\n",
+       "      <td>61</td>\n",
+       "      <td>71</td>\n",
+       "      <td>70</td>\n",
+       "      <td>49</td>\n",
+       "      <td>69</td>\n",
+       "      <td>97</td>\n",
+       "      <td>54</td>\n",
+       "      <td>66</td>\n",
+       "      <td>17</td>\n",
+       "      <td>68</td>\n",
+       "      <td>61</td>\n",
+       "      <td>64</td>\n",
+       "      <td>67.0</td>\n",
+       "      <td>32</td>\n",
+       "      <td>40</td>\n",
+       "      <td>24</td>\n",
+       "      <td>14</td>\n",
+       "      <td>7</td>\n",
+       "      <td>15</td>\n",
+       "      <td>6</td>\n",
+       "      <td>16</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>64+1</td>\n",
+       "      <td>64+1</td>\n",
+       "      <td>64+1</td>\n",
+       "      <td>56</td>\n",
+       "      <td>60</td>\n",
+       "      <td>60</td>\n",
+       "      <td>60</td>\n",
+       "      <td>56</td>\n",
+       "      <td>59+2</td>\n",
+       "      <td>59+2</td>\n",
+       "      <td>59+2</td>\n",
+       "      <td>57+2</td>\n",
+       "      <td>57+2</td>\n",
+       "      <td>57+2</td>\n",
+       "      <td>57+2</td>\n",
+       "      <td>57+2</td>\n",
+       "      <td>45+2</td>\n",
+       "      <td>49+2</td>\n",
+       "      <td>49+2</td>\n",
+       "      <td>49+2</td>\n",
+       "      <td>45+2</td>\n",
+       "      <td>44+2</td>\n",
+       "      <td>49+2</td>\n",
+       "      <td>49+2</td>\n",
+       "      <td>49+2</td>\n",
+       "      <td>44+2</td>\n",
+       "      <td>16+2</td>\n",
+       "      <td>2020</td>\n",
+       "      <td>0.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>82300</th>\n",
+       "      <td>113484</td>\n",
+       "      <td>9588</td>\n",
+       "      <td>156321</td>\n",
+       "      <td>A. Akinfenwa</td>\n",
+       "      <td>Saheed Adebayo Akinfenwa</td>\n",
+       "      <td>ST</td>\n",
+       "      <td>65</td>\n",
+       "      <td>65</td>\n",
+       "      <td>240000.0</td>\n",
+       "      <td>3000.0</td>\n",
+       "      <td>38</td>\n",
+       "      <td>1982-05-10</td>\n",
+       "      <td>178</td>\n",
+       "      <td>110</td>\n",
+       "      <td>1933.0</td>\n",
+       "      <td>Wycombe Wanderers</td>\n",
+       "      <td>English League Championship</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>SUB</td>\n",
+       "      <td>20.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2016-07-10</td>\n",
+       "      <td>2021.0</td>\n",
+       "      <td>14</td>\n",
+       "      <td>England</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Right</td>\n",
+       "      <td>3</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>Low/Low</td>\n",
+       "      <td>Unique</td>\n",
+       "      <td>Yes</td>\n",
+       "      <td>352000.0</td>\n",
+       "      <td>#Strength</td>\n",
+       "      <td>Solid Player, Power Header</td>\n",
+       "      <td>42.0</td>\n",
+       "      <td>64.0</td>\n",
+       "      <td>54.0</td>\n",
+       "      <td>56.0</td>\n",
+       "      <td>35.0</td>\n",
+       "      <td>81.0</td>\n",
+       "      <td>44</td>\n",
+       "      <td>64</td>\n",
+       "      <td>74</td>\n",
+       "      <td>60</td>\n",
+       "      <td>59</td>\n",
+       "      <td>50</td>\n",
+       "      <td>50</td>\n",
+       "      <td>42</td>\n",
+       "      <td>52</td>\n",
+       "      <td>68</td>\n",
+       "      <td>37</td>\n",
+       "      <td>46</td>\n",
+       "      <td>34</td>\n",
+       "      <td>63</td>\n",
+       "      <td>71</td>\n",
+       "      <td>71</td>\n",
+       "      <td>49</td>\n",
+       "      <td>65</td>\n",
+       "      <td>97</td>\n",
+       "      <td>56</td>\n",
+       "      <td>69</td>\n",
+       "      <td>17</td>\n",
+       "      <td>68</td>\n",
+       "      <td>61</td>\n",
+       "      <td>64</td>\n",
+       "      <td>68.0</td>\n",
+       "      <td>32</td>\n",
+       "      <td>40</td>\n",
+       "      <td>24</td>\n",
+       "      <td>14</td>\n",
+       "      <td>7</td>\n",
+       "      <td>15</td>\n",
+       "      <td>6</td>\n",
+       "      <td>16</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>65</td>\n",
+       "      <td>65</td>\n",
+       "      <td>65</td>\n",
+       "      <td>56</td>\n",
+       "      <td>60</td>\n",
+       "      <td>60</td>\n",
+       "      <td>60</td>\n",
+       "      <td>56</td>\n",
+       "      <td>59+2</td>\n",
+       "      <td>59+2</td>\n",
+       "      <td>59+2</td>\n",
+       "      <td>57+2</td>\n",
+       "      <td>57+2</td>\n",
+       "      <td>57+2</td>\n",
+       "      <td>57+2</td>\n",
+       "      <td>57+2</td>\n",
+       "      <td>45+2</td>\n",
+       "      <td>50+2</td>\n",
+       "      <td>50+2</td>\n",
+       "      <td>50+2</td>\n",
+       "      <td>45+2</td>\n",
+       "      <td>44+2</td>\n",
+       "      <td>49+2</td>\n",
+       "      <td>49+2</td>\n",
+       "      <td>49+2</td>\n",
+       "      <td>44+2</td>\n",
+       "      <td>17+2</td>\n",
+       "      <td>2021</td>\n",
+       "      <td>0.000000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       Unnamed: 0  Unnamed: 0.1  sofifa_id    short_name  \\\n",
+       "7422         9377          9377     156321  A. Akinfenwa   \n",
+       "18450       24934          8779     156321  A. Akinfenwa   \n",
+       "31262       42396         10618     156321  A. Akinfenwa   \n",
+       "43850       60285         10911     156321  A. Akinfenwa   \n",
+       "55238       76015          8687     156321  A. Akinfenwa   \n",
+       "69286       95396          9983     156321  A. Akinfenwa   \n",
+       "82300      113484          9588     156321  A. Akinfenwa   \n",
+       "\n",
+       "                      long_name player_positions  overall  potential  \\\n",
+       "7422   Saheed Adebayo Akinfenwa               ST       62         62   \n",
+       "18450  Saheed Adebayo Akinfenwa               ST       64         64   \n",
+       "31262  Saheed Adebayo Akinfenwa               ST       64         64   \n",
+       "43850  Saheed Adebayo Akinfenwa               ST       64         64   \n",
+       "55238  Saheed Adebayo Akinfenwa               ST       66         66   \n",
+       "69286  Saheed Adebayo Akinfenwa               ST       65         65   \n",
+       "82300  Saheed Adebayo Akinfenwa               ST       65         65   \n",
+       "\n",
+       "       value_eur  wage_eur  age         dob  height_cm  weight_kg  \\\n",
+       "7422    275000.0    2000.0   32  1982-05-10        178        110   \n",
+       "18450   300000.0    2000.0   33  1982-05-10        178        110   \n",
+       "31262   230000.0    7000.0   34  1982-05-10        178        110   \n",
+       "43850   210000.0    5000.0   35  1982-05-10        178        110   \n",
+       "55238   230000.0    3000.0   36  1982-05-10        178        110   \n",
+       "69286   160000.0    2000.0   37  1982-05-10        178        110   \n",
+       "82300   240000.0    3000.0   38  1982-05-10        178        110   \n",
+       "\n",
+       "       club_team_id          club_name                  league_name  \\\n",
+       "7422       112259.0      AFC Wimbledon           English League Two   \n",
+       "18450      112259.0      AFC Wimbledon           English League Two   \n",
+       "31262        1933.0  Wycombe Wanderers           English League Two   \n",
+       "43850        1933.0  Wycombe Wanderers           English League Two   \n",
+       "55238        1933.0  Wycombe Wanderers           English League One   \n",
+       "69286        1933.0  Wycombe Wanderers           English League One   \n",
+       "82300        1933.0  Wycombe Wanderers  English League Championship   \n",
+       "\n",
+       "       league_level club_position  club_jersey_number club_loaned_from  \\\n",
+       "7422            4.0            RS                10.0              NaN   \n",
+       "18450           4.0            LS                10.0              NaN   \n",
+       "31262           4.0           SUB                20.0              NaN   \n",
+       "43850           4.0            ST                20.0              NaN   \n",
+       "55238           3.0            ST                20.0              NaN   \n",
+       "69286           3.0            ST                20.0              NaN   \n",
+       "82300           2.0           SUB                20.0              NaN   \n",
+       "\n",
+       "      club_joined  club_contract_valid_until  nationality_id nationality_name  \\\n",
+       "7422   2014-06-20                     2015.0              14          England   \n",
+       "18450  2014-06-20                     2016.0              14          England   \n",
+       "31262  2016-07-10                     2017.0              14          England   \n",
+       "43850  2016-07-10                     2018.0              14          England   \n",
+       "55238  2016-07-10                     2022.0              14          England   \n",
+       "69286  2016-07-10                     2020.0              14          England   \n",
+       "82300  2016-07-10                     2021.0              14          England   \n",
+       "\n",
+       "       nation_team_id nation_position  nation_jersey_number preferred_foot  \\\n",
+       "7422              NaN             NaN                   NaN          Right   \n",
+       "18450             NaN             NaN                   NaN          Right   \n",
+       "31262             NaN             NaN                   NaN          Right   \n",
+       "43850             NaN             NaN                   NaN          Right   \n",
+       "55238             NaN             NaN                   NaN          Right   \n",
+       "69286             NaN             NaN                   NaN          Right   \n",
+       "82300             NaN             NaN                   NaN          Right   \n",
+       "\n",
+       "       weak_foot  skill_moves  international_reputation work_rate  \\\n",
+       "7422           3            2                         1   Low/Low   \n",
+       "18450          3            2                         1   Low/Low   \n",
+       "31262          3            2                         1   Low/Low   \n",
+       "43850          3            2                         1   Low/Low   \n",
+       "55238          3            2                         1   Low/Low   \n",
+       "69286          3            2                         1   Low/Low   \n",
+       "82300          3            2                         1   Low/Low   \n",
+       "\n",
+       "              body_type real_face  release_clause_eur player_tags  \\\n",
+       "7422   Stocky (170-185)        No                 NaN   #Strength   \n",
+       "18450            Unique       Yes                 NaN   #Strength   \n",
+       "31262            Unique       Yes                 NaN   #Strength   \n",
+       "43850            Unique       Yes            368000.0   #Strength   \n",
+       "55238            Unique       Yes            403000.0   #Strength   \n",
+       "69286            Unique       Yes            333000.0   #Strength   \n",
+       "82300            Unique       Yes            352000.0   #Strength   \n",
+       "\n",
+       "                                           player_traits  pace  shooting  \\\n",
+       "7422                                                 NaN  50.0      59.0   \n",
+       "18450                                                NaN  49.0      60.0   \n",
+       "31262                  Backs Into Player, Target Forward  45.0      60.0   \n",
+       "43850    Power Header, Backs Into Player, Target Forward  45.0      61.0   \n",
+       "55238  Injury Free, Power Header, Backs Into Player, ...  44.0      64.0   \n",
+       "69286                         Solid Player, Power Header  43.0      63.0   \n",
+       "82300                         Solid Player, Power Header  42.0      64.0   \n",
+       "\n",
+       "       passing  dribbling  defending  physic  attacking_crossing  \\\n",
+       "7422      53.0       61.0       34.0    78.0                  38   \n",
+       "18450     54.0       62.0       35.0    81.0                  39   \n",
+       "31262     51.0       60.0       35.0    80.0                  39   \n",
+       "43850     51.0       56.0       35.0    80.0                  39   \n",
+       "55238     53.0       57.0       33.0    83.0                  39   \n",
+       "69286     54.0       56.0       35.0    81.0                  44   \n",
+       "82300     54.0       56.0       35.0    81.0                  44   \n",
+       "\n",
+       "       attacking_finishing  attacking_heading_accuracy  \\\n",
+       "7422                    63                          68   \n",
+       "18450                   64                          69   \n",
+       "31262                   64                          68   \n",
+       "43850                   64                          71   \n",
+       "55238                   66                          71   \n",
+       "69286                   64                          72   \n",
+       "82300                   64                          74   \n",
+       "\n",
+       "       attacking_short_passing  attacking_volleys  skill_dribbling  \\\n",
+       "7422                        59                 58               60   \n",
+       "18450                       60                 59               61   \n",
+       "31262                       56                 59               59   \n",
+       "43850                       56                 59               52   \n",
+       "55238                       59                 59               52   \n",
+       "69286                       60                 59               52   \n",
+       "82300                       60                 59               50   \n",
+       "\n",
+       "       skill_curve  skill_fk_accuracy  skill_long_passing  skill_ball_control  \\\n",
+       "7422            49                 41                  49                  69   \n",
+       "18450           50                 42                  50                  71   \n",
+       "31262           50                 42                  47                  69   \n",
+       "43850           50                 42                  47                  69   \n",
+       "55238           50                 42                  47                  69   \n",
+       "69286           50                 42                  51                  67   \n",
+       "82300           50                 42                  52                  68   \n",
+       "\n",
+       "       movement_acceleration  movement_sprint_speed  movement_agility  \\\n",
+       "7422                      45                     54                41   \n",
+       "18450                     45                     52                32   \n",
+       "31262                     41                     49                29   \n",
+       "43850                     41                     49                29   \n",
+       "55238                     38                     49                35   \n",
+       "69286                     37                     48                35   \n",
+       "82300                     37                     46                34   \n",
+       "\n",
+       "       movement_reactions  movement_balance  power_shot_power  power_jumping  \\\n",
+       "7422                   59                70                54             57   \n",
+       "18450                  60                70                55             57   \n",
+       "31262                  61                70                57             50   \n",
+       "43850                  61                70                61             50   \n",
+       "55238                  61                71                70             49   \n",
+       "69286                  61                71                70             49   \n",
+       "82300                  63                71                71             49   \n",
+       "\n",
+       "       power_stamina  power_strength  power_long_shots  mentality_aggression  \\\n",
+       "7422              59              97                49                    59   \n",
+       "18450             69              98                50                    60   \n",
+       "31262             63              98                50                    63   \n",
+       "43850             63              98                51                    63   \n",
+       "55238             77              97                54                    66   \n",
+       "69286             69              97                54                    66   \n",
+       "82300             65              97                56                    69   \n",
+       "\n",
+       "       mentality_interceptions  mentality_positioning  mentality_vision  \\\n",
+       "7422                        25                     67                64   \n",
+       "18450                       17                     68                65   \n",
+       "31262                       17                     68                62   \n",
+       "43850                       17                     68                62   \n",
+       "55238                       17                     71                62   \n",
+       "69286                       17                     68                61   \n",
+       "82300                       17                     68                61   \n",
+       "\n",
+       "       mentality_penalties  mentality_composure  defending_marking_awareness  \\\n",
+       "7422                    66                  NaN                           25   \n",
+       "18450                   67                  NaN                           32   \n",
+       "31262                   66                 70.0                           33   \n",
+       "43850                   66                 70.0                           33   \n",
+       "55238                   66                 70.0                           27   \n",
+       "69286                   64                 67.0                           32   \n",
+       "82300                   64                 68.0                           32   \n",
+       "\n",
+       "       defending_standing_tackle  defending_sliding_tackle  \\\n",
+       "7422                          40                        25   \n",
+       "18450                         41                        24   \n",
+       "31262                         40                        24   \n",
+       "43850                         40                        24   \n",
+       "55238                         40                        24   \n",
+       "69286                         40                        24   \n",
+       "82300                         40                        24   \n",
+       "\n",
+       "       goalkeeping_diving  goalkeeping_handling  goalkeeping_kicking  \\\n",
+       "7422                   13                     6                   14   \n",
+       "18450                  14                     7                   15   \n",
+       "31262                  14                     7                   15   \n",
+       "43850                  14                     7                   15   \n",
+       "55238                  14                     7                   15   \n",
+       "69286                  14                     7                   15   \n",
+       "82300                  14                     7                   15   \n",
+       "\n",
+       "       goalkeeping_positioning  goalkeeping_reflexes  goalkeeping_speed    ls  \\\n",
+       "7422                         5                    15                NaN    62   \n",
+       "18450                        6                    16                NaN    64   \n",
+       "31262                        6                    16                NaN  63+1   \n",
+       "43850                        6                    16                NaN  63+1   \n",
+       "55238                        6                    16                NaN  65+1   \n",
+       "69286                        6                    16                NaN  64+1   \n",
+       "82300                        6                    16                NaN    65   \n",
+       "\n",
+       "         st    rs  lw  lf  cf  rf  rw   lam   cam   ram    lm   lcm    cm  \\\n",
+       "7422     62    62  56  60  60  60  56    60    60    60    56    56    56   \n",
+       "18450    64    64  58  62  62  62  58    61    61    61    59    59    59   \n",
+       "31262  63+1  63+1  57  61  61  61  57  59+1  59+1  59+1  57+1  56+1  56+1   \n",
+       "43850  63+1  63+1  56  60  60  60  56  58+1  58+1  58+1  56+1  56+1  56+1   \n",
+       "55238  65+1  65+1  57  61  61  61  57  59+1  59+1  59+1  57+1  58+1  58+1   \n",
+       "69286  64+1  64+1  56  60  60  60  56  59+2  59+2  59+2  57+2  57+2  57+2   \n",
+       "82300    65    65  56  60  60  60  56  59+2  59+2  59+2  57+2  57+2  57+2   \n",
+       "\n",
+       "        rcm    rm   lwb   ldm   cdm   rdm   rwb    lb   lcb    cb   rcb    rb  \\\n",
+       "7422     56    56    45    52    52    52    45    44    48    48    48    44   \n",
+       "18450    59    59    46    50    50    50    46    44    49    49    49    44   \n",
+       "31262  56+1  57+1  44+1  48+1  48+1  48+1  44+1  43+1  48+1  48+1  48+1  43+1   \n",
+       "43850  56+1  56+1  44+1  48+1  48+1  48+1  44+1  43+1  48+1  48+1  48+1  43+1   \n",
+       "55238  58+1  57+1  45+1  49+1  49+1  49+1  45+1  44+1  48+1  48+1  48+1  44+1   \n",
+       "69286  57+2  57+2  45+2  49+2  49+2  49+2  45+2  44+2  49+2  49+2  49+2  44+2   \n",
+       "82300  57+2  57+2  45+2  50+2  50+2  50+2  45+2  44+2  49+2  49+2  49+2  44+2   \n",
+       "\n",
+       "         gk  año_version  progresion_anual  \n",
+       "7422     13         2015          0.032258  \n",
+       "18450    16         2016          0.000000  \n",
+       "31262  16+1         2017          0.000000  \n",
+       "43850  16+1         2018          0.031250  \n",
+       "55238  16+1         2019         -0.015152  \n",
+       "69286  16+2         2020          0.000000  \n",
+       "82300  17+2         2021          0.000000  "
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# buscamos el outlier de height & weight\n",
+    "df[(df['weight_kg']>=110)&(df['height_cm']<=180)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "81d65a35",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.7642825221293341"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# lo comprobamos:\n",
+    "#df.drop(df[(df['weight_kg']>=110)&(df['height_cm']<=180)].index, inplace=True)['weight_kg'].corr(df.drop(df[(df['weight_kg']>=110)&(df['height_cm']<=180)].index, inplace=True)['height_cm'])\n",
+    "df['weight_kg'].corr(df['height_cm'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "516f7ac9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Hay alta correlación entre weight y height. Podríamos juntas las 2 o eliminar 1 y calcular los outliers de la nueva \\nvariable. Si la nueva variable pesa en la predicción podemos probar a eliminar los outliers por si distorsionan.'"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "'''Hay alta correlación entre weight y height. Podríamos juntas las 2 o eliminar 1 y calcular los outliers de la nueva \n",
+    "variable. Si la nueva variable pesa en la predicción podemos probar a eliminar los outliers por si distorsionan.'''"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fbcce43a",
+   "metadata": {},
+   "source": [
+    "### Variable skill_moves"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "c470f92a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([4, 5, 1, 3, 2], dtype=int64)"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df['skill_moves'].unique() #Variable de clasificación => no hay outliers"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "285b3a02",
+   "metadata": {},
+   "source": [
+    "### Variable international_reputation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "31ac1054",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([5, 4, 3, 2, 1], dtype=int64)"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df['international_reputation'].unique() #Variable de clasificación => no hay outliers"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2388c3e6",
+   "metadata": {},
+   "source": [
+    "### Variable release_clause_eur"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "325151ee",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<AxesSubplot:xlabel='release_clause_eur'>"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWAAAAEHCAYAAACQkJyuAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAAATDklEQVR4nO3de3CcV3nH8d+jiy05LiFItmUU7LUq2tg0wyUu5TYdhxqwnY5dxqEDg2tTmKEwrW2M4wy1FWzn0tIp4zRRB0paaJI2UwqThrGD5YBz62WARglxCBCKiuWCSh1bSZSqdoxWfvrHvtq8Wu1qVxfrkaXvZ2ZHu+97znnP2Xf1m6Oj3XfN3QUAmHpV0R0AgNmKAAaAIAQwAAQhgAEgCAEMAEFqxlK4sbHRM5nMBeoKAMxMjz/++Gl3X1C4fUwBnMlk1NnZOXm9AoBZwMxOFNvOEgQABCGAASAIAQwAQQhgAAhCAANAEAIYAIIQwAAQhAAGgCAEMAAEIYABIAgBDABBCGAACEIAA0AQAhgAghDAABCEAAaAIAQwAAQhgAEgCAEMAEHG9J1wE9He3q5HH31UktTc3DxsX2trq7Zu3TpVXQGAaWHKArirq0unTvdK1TX6n3MvH7b6zHNT1QUAmFamLIAlSdU1GpzXoLNXrMtvqn/m8JR2AQCmC9aAASAIAQwAQQhgAAhCAANAEAIYAIIQwAAQhAAGgCAEMAAEIYABIAgBDABBCGAACEIAA0AQAhgAghDAABCEAAaAIAQwAAQhgAEgCAEMAEEIYAAIQgADQBACGACCEMAAEIQABoAgBDAABCGAASAIAQwAQQhgAAhCAANAEAIYAIIQwAAQhAAGgCAEMAAEIYABIAgBDABBCGAACEIAA0AQAhgAghDAABCEAAaAIAQwAAQhgAEgyJQEcHt7u3p6eiZUv729fRJ7BADxaqbiIF1dXTp79uyE6gPATMMSBAAEIYABIAgBDABBCGAACEIAA0AQAhgAghDAABCEAAaAIAQwAAQhgAEgCAEMAEEIYAAIQgADQBACGACCEMAAEIQABoAgBDAABCGAASAIAQwAQQhgAAhCAANAEAIYAIIQwAAQhAAGgCAEMAAEIYABIAgBDABBCGAACEIAA0AQAhgAghDAABCEAAaAIAQwAAQhgAEgCAEMAEEIYAAIQgADQBACGACC1ER3oBLHjh2TJK1atSq2I7OImcndVV1drcHBQUnSvHnzdObMmXyZxsZG9fX1aWBgQA0NDerv79e5c+fy+zdt2qR77rlH7q6amhpls1k1NTXp5MmTWrRokU6ePCkz0/nz53XZZZfp+eef15w5c+TuymazevWrX61nn31WAwMDWrhwofr6+nTu3DnV1tYqm83qVa96lXp7e7Vz504tXrxY1113ncxM1dXVymaz+WNu3LhR9957r5YsWaJrr71WBw4cUFNTk/r6+tTe3q4XXnhB119/vRYsWKBTp07phhtu0H333ae9e/dKkvbv369t27bpM5/5jHp6erR48WJJUk9Pj8xMjY2NOn36tCRp8eLFqq+v10033aTjx49r165dWrZsmXbv3q3bb79d27ZtG/Zz7969amhoUG9vr/bv359//NBDD+nGG2/Uzp071dHRIXfXzTffLElqa2vTuXPn1NPTo6qqKrW3t6u1tXXY+Uu3NzSGwvsNDQ0lz39hfyot09vbq127dun48eP67Gc/q6uuuqpkuUr6MZH+jVav8Pm/EMeqhLl7xYVXrlzpnZ2dYz7I9u3b1dXVpf6XfqHBeQ06e8W6/L76Zw7rqpZFuu2220rWJ3gxGjPTJZdcov7+/orKpl/zmUxGp0+fHla3pqZGg4ODWr9+vdxdhw4d0tKlS9Xd3V1xnzZs2KAHH3ww324mk9GJEye0dOnSYT/Xr1+vHTt26MCBAzp06FD+8erVq5XNZof1d8OGDXJ3HTx4cNixMpmM7rzzzmHb0u0NjaHw/o4dO0r2v7A/lZY5cOBAvn/z58/X/fffX7JcJf2YSP9Gq1f4/F+IY6WZ2ePuvrJw+7RfgiB8UY67VxS+Q2XTuru7R9TNZrNyd3V0dORnn2MJX0n6+te/Pqzd7u7ufDvpn0eOHFFXV5eOHDmSf3zw4EFls9kR/T18+LA6OjpGHKu7u1tdXV35x729vfn20mPo6OgYdpze3t6ifU/XL1WuWJne3l4dPnw4X6a/v18PP/xw0XKV9KOU8dZP10s//6PVn2hfy5mSAO7p6dHZs2el84MjO/DSi+rq6tL27duL3oAoAwMD+SAcq0rrDQ4O6uabb9b58+fzj2+99daS/RkYGCi6b2h5QpLuuuuufHvpMaTrDw4O6u677y7aVrp+qXLFytx1110jxn3LLbcULVeu/dGMt3663pBy9Sfa13LKBrCZfdTMOs2s89SpU5N6cGA6c/cRM+bJls1m1d3dnQ+uodn3WKVn6EePHh02gx5qL30/m83qm9/8ZtG20vVLlStW5ujRo0XHV6xcufZHM9766Xrp/o1Wf6J9LadsALv7He6+0t1XLliwYFwHaW5uVn19vVRVPWLf+bpXqLW1VbfddlvRGxDFzGRmF/QYNTU1ymQyqqmpyT8ezzEzmUz+/urVq/PtpceQvl9TU6N3vetdRdtK1y9VrliZ1atXFx1fsXLl2h/NeOun66X7N1r9ifa1nGm/BgxEqa2tHfELW6lK61VXV6utrU1VVVX5x6X+0VNbW6va2tqi+9ra2vL3t2zZkm8vPYZ0/erqam3evLloW+n6pcoVK7Nly5YR496zZ0/RcuXaH81466frDSlXf6J9LWfaB/AjjzwS3QVMc2am+fPnV1w2LZPJjKg7NAtdu3at1q5dKzMbNsOsxDXXXDOs3Uwmk28n/XPNmjVqbW3VmjVr8o/Xr18/bAY7ZN26dVq7du2IY2UymWFvQ2toaMi3lx7D2rVrhx2n1Fuq0vVLlStWpqGhQevWvfwOp/nz5+vqq68uWq6SfpQy3vrpeunnf7T6E+1rOdM+gBFj6Be/uvrlZaN58+YNK9PY2JifUTU0NGju3LnD9m/atGnYn7yS1NTUJDPL/xyaXVx22WWSpDlz5qi2tlZmpubm5nz7CxcuzLc/tH/ol+GTn/yk9u3bl+93+k9GSdq4caMkacmSJfnZZVNTk+rr69XW1qZ9+/apqqpKixYtUlVVlfbs2aMrr7wyP1u78sor1dbWptbWVtXX16ulpUUtLS2aO3eu6urqdPnll6uurk51dXVatmyZVqxYoc2bN2vfvn0yM7W0tKitrS3fTvrn0Ixq6DhDj3fv3p0f24oVK7R8+fJ8f5YvX54//tAYCqXbK3V/NJWUK1Zmy5YtamlpkZlp//79o5arpB8T6d9o9Qqf/wtxrEpcFO8DHno3BGvCAC5GF+37gAFgpiKAASAIAQwAQQhgAAhCAANAEAIYAIIQwAAQhAAGgCAEMAAEIYABIAgBDABBCGAACEIAA0AQAhgAghDAABCEAAaAIAQwAAQhgAEgCAEMAEEIYAAIQgADQBACGACCEMAAEIQABoAgBDAABCGAASAIAQwAQQhgAAhCAANAEAIYAIIQwAAQhAAGgCAEMAAEIYABIAgBDABBCGAACEIAA0AQAhgAgtRMxUFaW1vV09Oj/pd+Me76ADDTTEkAb926VV1dXTr1fN+46wPATMMSBAAEIYABIAgBDABBCGAACEIAA0AQAhgAghDAABCEAAaAIAQwAAQhgAEgCAEMAEEIYAAIQgADQBACGACCEMAAEIQABoAgBDAABCGAASAIAQwAQQhgAAhCAANAEAIYAIIQwAAQhAAGgCAEMAAEIYABIAgBDABBCGAACEIAA0AQAhgAghDAABCEAAaAIAQwAAQhgAEgCAEMAEEIYAAIQgADQBACGACCEMAAEIQABoAgNVN6tMGsqs/0qv6Zw/lN1Week7RoSrsBANPBlAVwa2urenp6JEnNzenAXaTW1tap6gYATBvm7hUXXrlypXd2dl7A7gDAzGNmj7v7ysLtrAEDQBACGACCEMAAEIQABoAgBDAABCGAASAIAQwAQQhgAAhCAANAEAIYAIIQwAAQhAAGgCAEMAAEIYABIAgBDABBCGAACEIAA0AQAhgAghDAABCEAAaAIGP6Uk4zOyXpxDiP1Sjp9DjrzgSMf3aPX+I5mM3jX+ruCwo3jimAJ8LMOot9K+hswfhn9/glnoPZPv5iWIIAgCAEMAAEmcoAvmMKjzUdMX7M9udgto9/hClbAwYADMcSBAAEIYABIMikB7CZrTGzH5lZl5l9qsh+M7Pbk/1PmdmbJrsPkSoY/yoz6zOzJ5PbpyP6eaGY2ZfM7Fkze7rE/pl+/suNf6af/9eY2cNm9kMz+76ZbS9SZka/BsbE3SftJqla0n9KapE0R9IxSSsKyqyT1CHJJL1F0ncmsw+RtwrHv0rS/dF9vYDPwW9KepOkp0vsn7Hnv8Lxz/Tzv1jSm5L7vyTpP2ZTBoz1Ntkz4DdL6nL3n7j7LyR9WdKGgjIbJN3tOd+W9EozWzzJ/YhSyfhnNHf/Z0nPjVJkJp//SsY/o7n7z939ieT+/0r6oaTmgmIz+jUwFpMdwM2Sfpp6/DONfPIrKXOxqnRsbzWzY2bWYWavm5quTRsz+fxXalacfzPLSHqjpO8U7OI1kKiZ5PasyLbC97lVUuZiVcnYnlDuc+H9ZrZO0tckvfZCd2wamcnnvxKz4vyb2XxJ90r6hLu/WLi7SJXZ9BrIm+wZ8M8kvSb1+HJJ/z2OMhersmNz9xfdvT+5f1hSrZk1Tl0Xw83k81/WbDj/ZlarXPje4+7/VKTIrH4NpE12AD8m6bVmtszM5kh6v6SDBWUOStqc/Cf0LZL63P3nk9yPKGXHb2ZNZmbJ/Tcrdw56p7yncWby+S9rpp//ZGxflPRDdz9Qotisfg2kTeoShLtnzeyPJD2g3DsCvuTu3zezjyX7/0rSYeX+C9ol6Yyk35/MPkSqcPzXSvq4mWUlnZX0fk/+NTwTmNk/KPef/kYz+5mkvZJqpZl//qWKxj+jz7+kt0v6PUnfM7Mnk227JS2RZsdrYCz4KDIABOGTcAAQhAAGgCAEMAAEIYABIAgBDAAllLu4UkHZJcmFiL6bXGRoXbk6BDAAlHanpDUVlm2T9BV3f6NynwH4XLkKBDDGzMz6o/tQaDr2CRe/YhdXMrNfNrMjZva4mf2LmV0xVFzSK5L7l6qCT/dN9rUgMEMkn2gydz8f3ZeZzsyq3X0wuh+o2B2SPubuPzaz31BupvtOSfskfcPMtkq6RNLqcg0xA0aemWWSC2l/TrmLxtxgZo8l61n7S9TZVayMmX0tmSF838w+mmyrNrM7zexpM/ueme1ItpeaURQ73iIzuy+5mtgxM3tbwf75ZvagmT2RHGNDamxPp8pdZ2b7kvvbzOwHyRi+nGy7JFn/eyxZ0yt5WdFkXH+eeh7+INm+yszuT5X7SzP7UHK/28w+bWb/Kul9pdrG9JJcZOhtkr6afNLvC8pdA1mSPiDpTne/XLlP+v2dmY2ascyAUehXlfto6NeU+9jsm5W7etVBM/vN5E8ySZKZvVu5K3kVK/Nhd3/OzOolPWZm90rKSGp2919L6r8yaarUjKKY2yU96u7vNbNqSfML9r8k6b3u/qLlLnLzbTMrvB5JoU9JWubu51J92iPpIXf/cLLt383sqLv/X5H6H1Huega/bmZzJf2bmX2jzDEl6SV3f0cF5TB9VEl6wd3fUGTfR5SsF7v7t8ysTlKjpGdHawxIO5FcJPvdye27ys2Gr9DIyyaOVmabmR2T9G3lrnz1Wkk/kdRiZu1mtkbSi2VmFMW8U9LnJcndB929r2C/SfoTM3tK0lHlrjO7qMyYn5J0j5ltkpRNje1TSZ8ekVSn5HoGRbxbuYvLPKnctW8bVNklJv+xgjKYRpJLax43s/dJ+a9Xen2y+78k/Vayfblyr5lTo7XHDBiFhmZ4JulP3f0Lo5QtWsbMVim3/vVWdz9jZo9IqnP355MX63sk/aGk35X0CZWeUYzHByUtkHSVuw+YWbdyvwhZDZ9w1KXuX6PcVwmtV27Z5XXJ2Da6+48qOKZJ2uruDwzbaPaOUY4pvfxcY5oqcXGlD0r6vJm1KXehpS8r9/VjOyX9dbK05pI+VO5CS8yAUcoDkj6czFBlZs1mtrDCMpdKej4J3yuU+94vJUsCVe5+r6QblPvusNFmFMU8KOnjSdlqM3tFwf5LJT2bhO/VkpYm209KWmhmDckywW8nbVRJeo27PyzpekmvVG5Z4wFJW83yl458Y5nn6uOWuw6uzOxXzOwSSSckrTCzuWZ2qZLZES4e7v4Bd1/s7rXufrm7f9Hdj7v7Gnd/vbuvcPcbk7I/cPe3J9vf4O5ll6GYAaMod/9G8mfUt5IM6pe0San1rFHKHJH0sWQZ4EfKLUNIueWAv039Y+KPk5+lZhTFbJd0h5l9RNKgcmH8rdT+eyQdMrNOSU9Keibp64CZ3ajcEsHxoe3KXTb075OANEm3uvsLZnaTpL+Q9FQSwt1KQruIv1FuffuJpOwpSb/j7j81s68ot8TxY+WWaoA8LkcJAEFYggCAICxBYFoysz0a+f7Yr7r7LRH9kSQze4+kPyvYfNzd3xvRH1z8WIIAgCAsQQBAEAIYAIIQwAAQhAAGgCD/D/WT/z9oCfHFAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "sns.boxplot(x=df[df['release_clause_eur'].fillna(0)>0]['release_clause_eur']) #vemos que hay muchos outliers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "50c603be",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Hay 0 outliers por debajo de -2700000.0 y 13434 outliers por encima de 4500000.0.'"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "outliers(df['release_clause_eur'].fillna(0))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5f1db452",
+   "metadata": {},
+   "source": [
+    "## Variables que no afectan a porteros (GK)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "750c2123",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df=df[df['player_positions']!='GK']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6809a25d",
+   "metadata": {},
+   "source": [
+    "### Variable pace"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "4f2553b8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<AxesSubplot:xlabel='pace'>"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWcAAAEGCAYAAAC5EFRyAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAAAOiUlEQVR4nO3df2xd9XmA8eeNvZb8aNeSUMRMutvOCLoWSpOMQTshEwYLJHTTtEopAhJtjD82JQGmTYNkJZkC06RpGsrWiqjd+NHSSmPtViKUkZUgbdXU1kkhCUsQd2taSCmEoJUlYV1DvvvjHIdrx0ns2PfeN8nzkSz7HJ97zxvb98nx8fVxlFKQJOUypdsDSJKOZpwlKSHjLEkJGWdJSsg4S1JCvePZeNasWaXRaLRpFEk6PW3ZsuW1Uso547nNuOLcaDQYHBwc31SSdIaLiO+P9zae1pCkhIyzJCVknCUpIeMsSQkZZ0lKyDhLUkLGWZISMs6SlJBxlqSEjLMkJWScJSkh4yxJCRlnSUrIOEtSQsZZkhIyzpKUkHGWpISMsyQlZJwlKaFx/Q1B6XS0bt06ms1mx/a3Z88eAPr6+tq2j/7+fpYtW9a2+1f7GWed8ZrNJs/s2Mlb087uyP56Dv4YgB/9pD0Pv56Dr7flftVZxlkC3pp2Nm9edH1H9jV11xMAbdvf0P3r1OY5Z0lKyDhLUkLGWZISMs6SlJBxlqSEjLMkJWScJSkh4yxJCRlnSUrIOEtSQsZZkhIyzpKUkHGWpISMsyQlZJwlKSHjLEkJGWdJSsg4S1JCxlmSEjLOkpSQcZakhIyzJCVknCUpIeMsSQkZZ0lKyDhLUkLGWZISMs6SlJBxlqSEjLMkJWScJSkh4yxJCRlnSUrIOEtSQsZZkhIyzpKUkHGWpISMsyQlZJwlKSHjLEkJGWdJSsg4n4bWrVvHunXruj2GdErI+njp7fYAmnzNZrPbI0injKyPF4+cJSkh4yxJCRlnSUrIOEtSQsZZkhIyzpKUkHGWpISMsyQlZJwlKSHjLEkJGWdJSsg4S1JCxlmSEjLOkpSQcZakhIyzJCVknCUpIeMsSQkZZ0lKyDhLUkLGWZISMs6SlJBxlqSEjLMkJWScJSkh4yxJCRlnSUrIOEtSQsZZkhIyzpKUkHGWpISMsyQlZJwlKSHjLEkJGWdJSsg4S1JCxlmSEjLOkpRQR+I8ODjI/Pnz2bJly6jvbzabLFy4kGazOabbj9x+5PJTTz3FwMAAmzdvBmD58uUMDAxw5513AjAwMHDk5XRclnTyli5dysDAALfeeisA+/btY/ny5ezbt6+jc3QkzqtXr+bw4cPcc889o75/7dq1HDhwgLVr147p9iO3H7l83333AXDvvfcCsG3bNgC2bt06ef8oSael3bt3Axw52HvooYfYvn07Dz/8cEfnaHucBwcH2b9/PwD79+8/6ui52Wwe+WDs3r37qKPnkbd//PHHh22/efPmYcuPPvoohw4dAuDQoUPcfPPNw+5v5NHl6b4saeyWLl161PLGjRsppbBx48aOHj1HKWXMG8+bN68MDg6OaweLFi06EleAGTNmsGHDhiPLS5cuPRJXgEajwYMPPnjM20cErTP39vYeibEqs2bN4s0336S/v7/bo5wSms0m//N/hQOXLu7I/qbuegKANy+6vi33P/2Zr/Cud4Sf/zFqNptMnTqVxx57bNSDm6HG9Pb2snDhQu64445x7yMitpRS5o3nNic8co6I2yJiMCIG9+7dO+6hWsM62nJrmEdbHrn9yP9MDLOkdmr9TnzTpk0d22/viTYopawH1kN15DzeHcyYMeOoI+dWjUbjqCPn493eI+cT6+vrA+D+++/v8iSnhhUrVrDlv17p9hiT5vBZ76b/g+f6+R+jFStWHPf9rUfO11xzTYem6sA559WrVw9bXrNmzbDlVatWHXd55O2HnnExZOXKlcOWb7vttmHLs2fPHuuoks5wIw8OG40GU6ZUmezp6eGWW27p2Cxtj/O8efOOHC3PmDGDuXPnDnt/f3//kQ9Io9E46jzZyNvfcMMNw7a/6qqrhi3feOON9PZW3xD09vbyyCOPDLu/p59++oxaljR2rT/vGlpesGABEcGCBQuYOXNmx2bp2FPppkyZctRR85BVq1Yxffr0o46aj3X7kduPXL777ruBt4+qL7nkEgDmzJkzef8oSaeloYO9oQPFJUuWcPHFF3f0qBk68GwNdd7QOTTPOY7N0Dnndj17YqR2P1tj6q4nmOs55zHrxOOlLc/WkCR1nnGWpISMsyQlZJwlKSHjLEkJGWdJSsg4S1JCxlmSEjLOkpSQcZakhIyzJCVknCUpIeMsSQkZZ0lKyDhLUkLGWZISMs6SlJBxlqSEjLMkJWScJSkh4yxJCRlnSUrIOEtSQsZZkhIyzpKUkHGWpISMsyQlZJwlKSHjLEkJGWdJSsg4S1JCxlmSEjLOkpSQcZakhIyzJCVknCUpIeMsSQkZZ0lKqLfbA2jy9ff3d3sE6ZSR9fFinE9Dy5Yt6/YI0ikj6+PF0xqSlJBxlqSEjLMkJWScJSkh4yxJCRlnSUrIOEtSQsZZkhIyzpKUkHGWpISMsyQlZJwlKSHjLEkJGWdJSsg4S1JCxlmSEjLOkpSQcZakhIyzJCVknCUpIeMsSQkZZ0lKyDhLUkLGWZISMs6SlJBxlqSEjLMkJWScJSkh4yxJCRlnSUrIOEtSQsZZkhIyzpKUkHGWpISMsyQlZJwlKSHjLEkJGWdJSsg4S1JCxlmSEurt9gBSBj0HX2fqric6tK99AG3bX8/B14Fz23Lf6hzjrDNef39/R/e3Z88hAPr62hXQczv+b9LkM8464y1btqzbI0hH8ZyzJCVknCUpIeMsSQkZZ0lKyDhLUkLGWZISMs6SlJBxlqSEjLMkJWScJSkh4yxJCRlnSUrIOEtSQsZZkhIyzpKUkHGWpISMsyQlZJwlKSHjLEkJGWdJSihKKWPfOGIv8P0xbj4LeO1khuoQ55sY55sY55uYU22+ny+lnDOeOxhXnMd1xxGDpZR5bbnzSeB8E+N8E+N8E3MmzOdpDUlKyDhLUkLtjPP6Nt73ZHC+iXG+iXG+iTnt52vbOWdJ0snztIYkJWScJSmhCcc5ImZHxOaI2BkRz0XEinr92RGxKSJeqF+/d+LjntR8Z0XEtyPi2Xq+NZnma5mzJyK+GxEbss0XEbsjYntEPBMRgwnne09EPBYRu+qvwyuSzXdh/bEbenkjIm7PMmNE3FE/NnZExJfrx0yK2er5VtSzPRcRt9frujpfRPxtRLwaETta1h1zpoi4KyKaEfF8RPzaWPYxGUfOh4A/KKV8CLgc+P2I+EXgj4FvlFIuAL5RL3fDT4D5pZSPApcCCyLi8kTzDVkB7GxZzjbfVaWUS1ueu5lpvvuBjaWUi4CPUn0c08xXSnm+/thdCswFDgJfyzBjRPQBy4F5pZSPAD3A4gyz1fN9BPhd4DKqz+2iiLggwXwPAgtGrBt1prqHi4EP17f5bET0nHAPpZRJfQH+CbgGeB44r153HvD8ZO/rJGabBmwFfjnTfMD59SdzPrChXpdpvt3ArBHrUswHvBv4HvUPt7PNN8q81wLfzDIj0Ae8CJwN9AIb6hm7Plu9708Bn29Z/hPgjzLMBzSAHSf6mgPuAu5q2e6fgStOdP+Tes45IhrAx4BvAeeWUl4GqF+/bzL3Nc65eiLiGeBVYFMpJdV8wF9RfcEdblmXab4CPBkRWyLitnpdlvk+COwF/q4+LfT5iJieaL6RFgNfrt/u+oyllD3AXwA/AF4GflxKeTLDbLUdwJURMTMipgHXA7MTzdfqWDMN/Qc45KV63XFNWpwjYgbwD8DtpZQ3Jut+J0Mp5a1SfUt5PnBZ/a1SChGxCHi1lLKl27McxydKKXOA66hOW13Z7YFa9AJzgM+VUj4GHKD7p4BGFRHvAD4J/H23ZxlSnxf9deADwM8B0yPipu5O9bZSyk7gz4FNwEbgWapTqaeSGGXdCZ/DPClxjoifoQrzl0opX61XvxIR59XvP4/qqLWrSin/DTxNdd4ny3yfAD4ZEbuBrwDzI+KLieajlPLD+vWrVOdKL0s030vAS/V3QwCPUcU6y3ytrgO2llJeqZczzPirwPdKKXtLKT8Fvgp8PMlsAJRSvlBKmVNKuRJ4HXgh03wtjjXTS1RH+0POB354ojubjGdrBPAFYGcp5S9b3vV1YEn99hKqc9EdFxHnRMR76renUn0x7soyXynlrlLK+aWUBtW3vE+VUm7KMl9ETI+Idw29TXU+ckeW+UopPwJejIgL61VXA/9BkvlG+DRvn9KAHDP+ALg8IqbVj+WrqX6gmmE2ACLiffXr9wO/SfUxTDNfi2PN9HVgcUS8MyI+AFwAfPuE9zYJJ8V/heoQfRvwTP1yPTCT6odcL9Svz+70Cft6vkuA79bz7QA+U69PMd+IWQd4+weCKeajOqf7bP3yHLAy03z1LJcCg/Xn+B+B92aar55xGrAP+NmWdSlmBNZQHbDsAB4B3plltnq+f6X6D/dZ4OoMHzuq/yBeBn5KdWT8O8ebCVgJ/CfVDw2vG8s+/PVtSUrI3xCUpISMsyQlZJwlKSHjLEkJGWdJSsg4S1JCxlmSEjLOSisiGvU1mh+KiG31NZunRcRnIuI79TV+19e/2UZE9EfEv0R17e6tEfEL9fo/rLffFvX1vKXsjLOyuxBYX0q5BHgD+D3gr0spv1Sq6w9PBRbV234J+JtSXbv748DLEXEt1a/LXkb1m4Rzk124SRqVcVZ2L5ZSvlm//UWqywVcFRHfiojtVNfA/nB9/Y++UsrXAEop/1tKOUh1LZBrqX6FfytwEVWspdR6uz2AdAIjry9QgM9S/eWOFyNiNXAWo1+WkXr9n5VSHmjfiNLk88hZ2b0/Iq6o3/408G/126/V1xD/LYBSXUP8pYj4DYD6CmDTqP7qxG/X2xIRfUNXOZMy88hZ2e0ElkTEA1RX+/oc1VXntlP9+azvtGx7M/BARPwp1dXCPlVKeTIiPgT8e/1zw/3ATeS4/q90TF6VTmnVf/ZsQ/2DP+mM4mkNSUrII2dJSsgjZ0lKyDhLUkLGWZISMs6SlJBxlqSE/h9VLCo21Ks8CwAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "sns.boxplot(x=df['pace']) #los porteros no tienen pace"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "5e43ca0f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Hay 1995 outliers por debajo de 43.5 y 17 outliers por encima de 95.5.'"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "outliers(df['pace'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "df43adab",
+   "metadata": {},
+   "source": [
+    "### Variable shooting"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "47263a9d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<AxesSubplot:xlabel='shooting'>"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWAAAAEGCAYAAABbzE8LAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAAALs0lEQVR4nO3de4xm9V3H8c+X3Wp3sbdlKaFDda1bi00LlBLEthCEapA0bWKi1tjIXzatZlwaG+Mlaol/mEajkk1sQ9oYtaZVsVbFhkB6iVVjzS63LgJlYull28JSFKpLaQs//3jOykr2wsLOfM8sr1eymZkzO8/zyTDz3mfOMGdqjBEA1t5J3QMAnqkEGKCJAAM0EWCAJgIM0GTjsfzlrVu3jm3btq3SFIAT0+7du+8fY5z6xOPHFOBt27Zl165dx28VwDNAVX3+UMedggBoIsAATQQYoIkAAzQRYIAmAgzQRIABmggwQBMBBmgiwABNBBigiQADNBFggCYCDNBEgAGaCDBAEwEGaCLAAE0EGKDJMf1OOJ6Zdu7cmZWVle4Zx2zv3r1JkqWlpeYlC9u3b8/y8nL3DGZEgDmqlZWV3LLnjjy6eUv3lGOyYf+DSZKvPtL/Yb5h/wPdE5ih/o9M1oVHN2/Jw2de3j3jmGy686NJMovdB7bAwZwDBmgiwABNBBigiQADNBFggCYCDNBEgAGaCDBAEwEGaCLAAE0EGKCJAAM0EWCAJgIM0ESAAZoIMEATAQZoIsAATQQYoIkAAzQRYIAmAgzQRIABmggwQBMBBmgiwABNBBigiQADNBFggCYCDNBEgAGaCDBAEwEGaCLAAE0EGKCJAAM0EWCAJgIM0ESAAZoIMEATAQZosiYB3rlzZ3bu3LkWdwVwXK1mvzauyq0+wcrKylrcDcBxt5r9cgoCoIkAAzQRYIAmAgzQRIABmggwQBMBBmgiwABNBBigiQADNBFggCYCDNBEgAGaCDBAEwEGaCLAAE0EGKCJAAM0EWCAJgIM0ESAAZoIMEATAQZoIsAATQQYoIkAAzQRYIAmAgzQRIABmggwQBMBBmgiwABNBBigiQADNBFggCYCDNBEgAGaCDBAEwEGaCLAAE0EGKDJxrW4k7179+bhhx/Ojh071uLuOM5WVlZy0jdH94x17aRvPJSVla/7HFiHVlZWsmnTplW57aM+Aq6qt1bVrqratW/fvlUZAfBMdNRHwGOMa5JckyTnnXfeU3oYtLS0lCS5+uqrn8qb02zHjh3Z/R/3ds9Y1x579nOz/SWn+RxYh1bzqxbngAGaCDBAEwEGaCLAAE0EGKCJAAM0EWCAJgIM0ESAAZoIMEATAQZoIsAATQQYoIkAAzQRYIAmAgzQRIABmggwQBMBBmgiwABNBBigiQADNBFggCYCDNBEgAGaCDBAEwEGaCLAAE0EGKCJAAM0EWCAJgIM0ESAAZoIMEATAQZoIsAATQQYoIkAAzQRYIAmAgzQRIABmggwQJONa3En27dvX4u7ATjuVrNfaxLg5eXltbgbgONuNfvlFARAEwEGaCLAAE0EGKCJAAM0EWCAJgIM0ESAAZoIMEATAQZoIsAATQQYoIkAAzQRYIAmAgzQRIABmggwQBMBBmgiwABNBBigiQADNBFggCYCDNBEgAGaCDBAEwEGaCLAAE0EGKCJAAM0EWCAJgIM0ESAAZoIMEATAQZoIsAATQQYoIkAAzQRYIAmAgzQRIABmmzsHsD6sGH/A9l050e7ZxyTDfu/liSz2L1h/wNJTuuewcwIMEe1ffv27glPyd69306SLC3NIXynrdv3I6tHgDmq5eXl7glwQnIOGKCJAAM0EWCAJgIM0ESAAZoIMEATAQZoIsAATQQYoIkAAzQRYIAmAgzQRIABmggwQBMBBmgiwABNBBigiQADNBFggCYCDNCkxhhP/i9X7Uvy+dWb85RtTXJ/94jDmOu2ue5K5rttrruS+W6b665kbbd9zxjj1CcePKYAz1VV7RpjnNe941Dmum2uu5L5bpvrrmS+2+a6K5nHNqcgAJoIMECTEyXA13QPOIK5bpvrrmS+2+a6K5nvtrnuSmaw7YQ4BwywHp0oj4AB1h0BBmiyrgJcVS+uqk9U1R1VdXtV7ZiOb6mqG6vq7unpCxq2Pbuq/q2qbp22XTWXbdOODVV1c1VdN7Nd91TVZ6rqlqraNbNtz6+qa6vqzulj7oe6t1XVy6b31YE/D1XVld27pm3vmD7291TVB6fPifZd07Yd067bq+rK6Vj7tnUV4CTfTvJLY4wfSHJBkl+oqpcn+ZUkHxtjvDTJx6aX19ojSS4ZY5yd5Jwkl1XVBTPZliQ7ktxx0Mtz2ZUkPzzGOOeg/ydzLtuuTnL9GOPMJGdn8f5r3TbGuGt6X52T5NVJ9if5m+5dVbWU5BeTnDfGeEWSDUne3L1r2vaKJD+X5Pws/ju+oapeOodtGWOs2z9J/jbJjyS5K8np07HTk9zVvGtzkpuS/OActiU5I4sPsEuSXDcda9813fc9SbY+4Vj7tiTPTfK5TN+ontO2g7b8aJJ/nsOuJEtJvphkS5KNSa6b9rW/v5L8RJL3HfTybyT55TlsW2+PgP9PVW1L8qokn05y2hjjK0kyPX1h06YNVXVLkvuS3DjGmMu2P8ziA+6xg47NYVeSjCQ3VNXuqnrrjLa9JMm+JH88nbp5X1WdPJNtB7w5yQen51t3jTH2Jvm9JF9I8pUkD44xbujeNdmT5KKqOqWqNie5PMmL57BtXQa4qr4ryV8nuXKM8VD3ngPGGI+OxZeGZyQ5f/rSp1VVvSHJfWOM3d1bDuO1Y4xzk/xYFqeULuoeNNmY5Nwk7xljvCrJ/6T3NM3/U1XfkeSNSf6qe0uSTOdP35Tke5O8KMnJVfWW3lULY4w7krw7yY1Jrk9yaxanM9utuwBX1bOyiO+fjzE+PB2+t6pOn15/ehaPQNuMMf4rySeTXJb+ba9N8saquifJh5JcUlUfmMGuJMkY48vT0/uyOJd5/ky2fSnJl6avYpLk2iyCPIdtyeIfrJvGGPdOL3fven2Sz40x9o0xvpXkw0leM4NdSZIxxvvHGOeOMS5K8kCSu+ewbV0FuKoqyfuT3DHG+P2DXvV3Sa6Ynr8ii3PDa73t1Kp6/vT8piw+IO/s3jbG+NUxxhljjG1ZfMn68THGW7p3JUlVnVxVzznwfBbnDPfMYdsY46tJvlhVL5sOXZrk3+ewbfLTefz0Q9K/6wtJLqiqzdPn6aVZfNOye1eSpKpeOD397iQ/nsX7rn/bWp90fpon01+XxTnD25LcMv25PMkpWXyT6e7p6ZaGbWcluXnatifJb07H27cdtPHiPP5NuPZdWZxnvXX6c3uSX5/LtmnHOUl2Tf9NP5LkBXPYlsU3eb+W5HkHHZvDrquyeNCxJ8mfJfnOOeyatn0qi39Ab01y6VzeZ34UGaDJujoFAXAiEWCAJgIM0ESAAZoIMEATAWYWpquibT0Ot3NxVb3moJffVlU/+3RvF1bDxu4BcJxdnOS/k/xLkowx3tu6Bo7AI2DW3PQTcP9Qi2sn76mqn5petVxVN03XBz5z+rtbquojVXVbVf1rVZ11uOPTBZreluQd07VyL6yqd1XVO6e3+WRVvbsW123+bFVdOB3fXFV/Od3WX1TVp6tqlr9KnROLANPhsiRfHmOcPRbXjr1+On7/WFyY5z1J3jkduyrJzWOMs5L8WpI/PdzxMcY9Sd6b5A/G4pq5nzrEfW8cY5yf5MokvzUd+/kk/znd1m9ncZ1dWHUCTIfPJHn99Gj0wjHGg9PxAxdX2p1k2/T867L4sdaMMT6e5JSqet4Rjh/N4e7jQ9Nt7cniR49h1TkHzJobY3y2ql6dxXU8fqeqbphe9cj09NE8/rFZh7qJIxw/mid7H7DqPAJmzVXVi5LsH2N8IIuLeJ97hL/+j0l+Znq7i7M4TfHQEY5/PclzjnHSPyX5yem2Xp7klcf49vCUeARMh1cm+d2qeizJt5K8PYvr7R7Ku7L4rRS3ZfH7z644yvG/T3JtVb0pyfKT3PNHSf5kuq0DV7R78MhvAk+fq6HxjFdVG5I8a4zxjar6viwuTfj9Y4xvNk/jBOcRMCyur/uJ6betVJK3iy9rwSNggCa+CQfQRIABmggwQBMBBmgiwABN/hetVL/ncAJsAwAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "sns.boxplot(x=df['shooting']) #los porteros no tienen pace"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "5a52b8f0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Hay 0 outliers por debajo de 11.5 y 0 outliers por encima de 95.5.'"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "outliers(df['shooting'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "56dbf7cf",
+   "metadata": {},
+   "source": [
+    "### Variable passing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "0fd735e8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<AxesSubplot:xlabel='passing'>"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWAAAAEGCAYAAABbzE8LAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAAAO5UlEQVR4nO3dfWxd9XnA8e+TeICT0AKBopDQep0r2AZtoBmj60ZNgBASYNLGVJAsgjRWTSt5gU3QASugBbSgkYLCVo3SDViqIi2D8qIQEV4ybUhra5eXBAjDWtNCSiEEFRbIwgK//XGOwXFCGju+fo6T70eyfO+xc89jx/fr45+vz41SCpKk0TcuewBJ2l8ZYElKYoAlKYkBlqQkBliSkrQN5Z0PP/zw0tHR0aJRJGnf1Nvb+3op5YjB24cU4I6ODnp6ekZuKknaD0TET3a13SUISUpigCUpiQGWpCQGWJKSGGBJSmKAJSmJAZakJAZYkpIYYElKYoAlKYkBlqQkBliSkhhgSUpigCUpiQGWpCQGWJKSGGBJSmKAJSmJAZakJEN6TjhpuJYtW0ZfX1/2GGzcuBGAqVOntnQ/nZ2dzJ8/v6X70NhngDUq+vr6eGrd87w34bDUOca/8yYAP9/Wui/98e+80bLb1r7FAGvUvDfhMLYeOyd1hvb1KwFaOkf/PqRfxjVgSUpigCUpiQGWpCQGWJKSGGBJSmKAJSmJAZakJAZYkpIYYElKYoAlKYkBlqQkBliSkhhgSUpigCUpiQGWpCQGWJKSGGBJSmKAJSmJAZakJAZYkpIYYElKYoAlKYkBlqQkBliSkhhgSUpigCUpiQGWpCQGWJKSGGBJSmKAJSmJAZakJAZYkpIYYElKYoAlKYkBlqQkBliSkhhgSUpigCUpiQGWpCQGWJKSGGBJSmKAB1i2bBnLli3LHkPSR9jX7qNt2QM0SV9fX/YIknZjX7uPegQsSUkMsCQlMcCSlMQAS1ISAyxJSQywJCUxwJKUxABLUhIDLElJDLAkJTHAkpTEAEtSEgMsSUkMsCQlMcCSlMQAS1ISAyxJSQywJCUxwJKUxABLUhIDLElJDLAkJTHAkpTEAEtSEgMsSUkMsCQlMcCSlMQAS1ISAyxJSQywJCUxwJKUxABLUhIDLElJDLAkJTHAkpTEAEtSEgMsSUkMsCQlGZUAb968mQULFrB58+Zh38aSJUvo6uripptuAqC7u5uuri4uuugiALq6uj54Gc51SWPPrFmz6Orq4swzzwTgggsuoKuri+7u7g/eZ3A77rvvPrq6unjggQcAeOyxx+jq6uLxxx8HoKenh5kzZ9Lb2wtAX18fc+fOpa+vb8TnH5UA33nnnaxdu5a77rpr2Lfx0EMPAXzwSXv55ZcB2LBhw17PJ2lsevfddwHYtm0bAK+88grwYR9g53bcfPPNACxduhSAG264AYDrr78egGuvvZb333+fa665BoDFixfz9ttvs3jx4hGfv+UB3rx5M6tWraKUwqpVq4Z1FLxkyZIdrp911lk7XB98FLu31yU136xZs3a4Pvh+3N3dvVM7LrnkEkopAJRSuPHGG9m+fTsA27dv5/bbb2fLli0AbNmyhfvvv/+Dg7wNGzaM+FFw9A+zJ2bMmFF6enqGtIOlS5eycuVKtm/fTltbG3PnzuXSSy8d0m2MRiDXrFnDeeedx9atW+ns7Gz5/vY3fX19/M+7hbenn586R/v6lQBsPXZOy/Yx8am7OfiA8OuoBfr6+mhvb2fFihWj0oWIYGAjOzo6uOOOO4ZzO72llBmDt//SI+CI+EpE9EREz6ZNm4a840ceeWSH7zCrV68e8m1IUobBB6gjveTZtgcD3AbcBtUR8FB3cPrpp+9wBHzGGWcMY8zRMXXqVABuueWW5En2PQsXLqT3v1/NHmNUvH/Qx+j89JF+HbXAwoULR3V/uzoCHkktXwOeN28e48ZVuxk/fjwXXnjhkG9j8Jpve3v7iMwmaew64IADdvv2adOm7dSO4447bofrc+bsuBQ18NETwE7LpVdfffVQx9ytlgd48uTJzJ49m4hg9uzZTJ48eci3ccUVV+xwvf+3mv3WrFkzotclNd/DDz+8w/XB9+Ply5fv1I5bb72ViACqo9vLL7+ctrZqIaCtrY2LL76YSZMmATBp0iTOPffcD456Ozo6Rnxdf1QehjZv3jyOP/74YR399uv/TnbOOecA1Xc3GPkfCSSNHf1HwQceeCAAU6ZMAT7sA+zcjkWLFgFw2WWXAXDllVcCcNVVVwHVw9DGjRvHddddB1RHvRMnThzxo18YhUdBjCX960uu3Y28/jXgVj76YE+MxqMg2tev5POuAbfEWL2PDvtREJKk1jDAkpTEAEtSEgMsSUkMsCQlMcCSlMQAS1ISAyxJSQywJCUxwJKUxABLUhIDLElJDLAkJTHAkpTEAEtSEgMsSUkMsCQlMcCSlMQAS1ISAyxJSQywJCUxwJKUxABLUhIDLElJDLAkJTHAkpTEAEtSEgMsSUkMsCQlMcCSlMQAS1ISAyxJSQywJCUxwJKUxABLUhIDLElJDLAkJTHAkpSkLXuAJuns7MweQdJu7Gv3UQM8wPz587NHkLQb+9p91CUISUpigCUpiQGWpCQGWJKSGGBJSmKAJSmJAZakJAZYkpIYYElKYoAlKYkBlqQkBliSkhhgSUpigCUpiQGWpCQGWJKSGGBJSmKAJSmJAZakJAZYkpIYYElKYoAlKYkBlqQkBliSkhhgSUpigCUpiQGWpCQGWJKSGGBJSmKAJSmJAZakJAZYkpIYYElKYoAlKYkBlqQkBliSkhhgSUpigCUpiQGWpCQGWJKStGUPoP3H+HfeoH39yuQZNgO0dI7x77wBHNmy29e+wwBrVHR2dmaPAMDGjdsBmDq1lYE8sjEfr5rNAGtUzJ8/P3sEqXFcA5akJAZYkpIYYElKYoAlKYkBlqQkBliSkhhgSUpigCUpiQGWpCQGWJKSGGBJSmKAJSmJAZakJAZYkpIYYElKYoAlKYkBlqQkBliSkhhgSUpigCUpSZRS9vydIzYBPxnmvg4HXh/mvx1NY2HOsTAjOOdIGgszgnN+lE+VUo4YvHFIAd4bEdFTSpkxKjvbC2NhzrEwIzjnSBoLM4JzDpVLEJKUxABLUpLRDPBto7ivvTEW5hwLM4JzjqSxMCM455CM2hqwJGlHLkFIUhIDLElJRjzAEXF0RDweEc9HxLMRsbDeflhErI6IF+vXh470voc450ER8YOIeLqe87omzlnPND4inoyIBxs844aIWBsRT0VET4PnPCQiVkTE+vpr9AtNmzMijqk/j/0vb0XEogbOeWl931kXEd+t71ONmrGec2E947MRsaje1og5W3EEvB3481LKrwMnA1+NiN8AvgY8Wkr5DPBofT3TNmBmKeVzwHRgdkScTPPmBFgIPD/gehNnBDi1lDJ9wOMrmzjnLcCqUsqxwOeoPq+NmrOU8kL9eZwOfB54B7iXBs0ZEVOBBcCMUspxwHjg/CbNCBARxwF/ApxE9f99dkR8hqbMWUpp6QtwH3AG8AIwpd42BXih1fsewowTgB8Bv920OYFpVF8gM4EH622NmrGeYwNw+KBtjZoT+BjwY+pfPjd1zkGzzQKeaNqcwFTgJeAwoA14sJ61MTPWM/wRcPuA638FXN6UOVu6BhwRHcAJwPeBI0sprwDUrz/Ryn3vifpH+6eA14DVpZQmznkz1RfM+wO2NW1GgAI8HBG9EfGVelvT5vw0sAn4p3pJ5/aImEjz5hzofOC79eXGzFlK2Qj8LfBT4BXgzVLKw02asbYOOCUiJkfEBGAOcDQNmbNlAY6IScC/AotKKW+1aj97o5TyXql+zJsGnFT/uNIYEXE28FoppTd7lj3wxVLKicBZVMtOp2QPtAttwInAN0spJwBv04xlkV2KiAOAc4F/yZ5lsHrN9PeBXwWOAiZGRHfuVDsrpTwPLAFWA6uAp6mWSRuhJQGOiF+hiu93Sin31JtfjYgp9dunUB11NkIp5RfAGmA2zZrzi8C5EbEBuBuYGRHLadaMAJRSfla/fo1qvfIkmjfny8DL9U86ACuogty0OfudBfyolPJqfb1Jc54O/LiUsqmU8n/APcDvNGxGAEop3y6lnFhKOQV4A3iRhszZikdBBPBt4PlSytIBb7ofmFdfnke1NpwmIo6IiEPqy+1UX1DradCcpZS/LKVMK6V0UP0o+lgppZsGzQgQERMj4uD+y1Rrgeto2JyllJ8DL0XEMfWm04DnaNicA1zAh8sP0Kw5fwqcHBET6vv8aVS/0GzSjABExCfq158E/oDqc9qMOVuw6P27VOuBzwBP1S9zgMlUv0x6sX59WPLi/GeBJ+s51wFfr7c3as4B83bx4S/hGjUj1drq0/XLs8BVTZyznmk60FP/v38POLShc04ANgMfH7CtUXMC11EdtKwD/hk4sGkz1nP+O9U32qeB05r0ufRPkSUpiX8JJ0lJDLAkJTHAkpTEAEtSEgMsSUkMsPZJEXFURKzInkPaHR+GJklJPAJWqojoqM/Ne2dEPFOfq3dCRHw9In5Yn8f1tvqvrYiIBRHxXP2+d9fbvjTg3LlPRsTB9e2uq99+UUTcExGr6vO/3jhg/38cEf8VEWsi4lsRcWvOZ0L7IwOsJjgGuK2U8lngLeDPgFtLKb9VqnPNtgNn1+/7NeCE+n3/tN72F8BXS3Vipd8Dtu5iH9OBLwPHA1+O6okDjqI6PeHJVKdMPbYFH5v0kQywmuClUsoT9eXlVH/OfmpEfD8i1lKdC/k367c/A3ynPvNW/1mtngCWRsQC4JBSyq7OdvVoKeXNUsr/Uv1Z6qeoThj0b6WUN0p1QpnGnXVM+zYDrCYY/IuIAvw9cF4p5XjgW8BB9dvmAn9H9UwRvRHRVkr5G+BiqiPl/4yIXR3Jbhtw+T2qU1PGyH0I0tAZYDXBJyPiC/XlC4D/qC+/Xp9X+jyAiBgHHF1KeZzqJPWHAJMi4tdKKWtLKUuoTrSzp0sJPwC+FBGHRkQb8Icj8+FIe6YtewCJ6jSG8yLiH6jOTvVNqrOUraV6qqMf1u83HlgeER+nOnr9RinlFxHx1xFxKtWR7XPAQ1RPM7NbpZSNEXED1TO2/Kz+t2+O5Acm7Y4PQ1Oq+mmrHqx/2Zax/0mllC31EfC9wD+WUu7NmEX7H5cgtL+7tn5ewHVUT9j5vdRptF/xCFiSkngELElJDLAkJTHAkpTEAEtSEgMsSUn+Hy+46jC02zRUAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "sns.boxplot(x=df['passing'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "ef1b2503",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Hay 380 outliers por debajo de 30.0 y 69 outliers por encima de 86.0.'"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "outliers(df['passing'])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.8"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
- Añadido nuevo dataset filtrando las filas de jugadores con valores progresión anual. "players_total2"
- Para completar la detección de outliers se debería primero agrupar las posiciones de los jugadores en 4 (portero, defensa, medio y delantero). Después deberíamos volver a evaluar los outliers por cada posición porque hay variables que sólo afectan a una determinada posición. 